### PR TITLE
feat: add unified `format` and `out-file` options and new output format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.8.0"
-    kotlin("plugin.serialization") version "1.8.0"
+    kotlin("plugin.serialization") version "1.8.10"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("org.graalvm.buildtools.native") version "0.9.19"
 }
@@ -23,6 +23,7 @@ dependencies {
     implementation("com.github.handymenny.mts-asn1:mts-asn1-converter:d9687dc")
     implementation("com.github.handymenny.mts-asn1:mts-asn1-per:d9687dc")
     implementation("com.github.handymenny.mts-asn1:mts-asn1-kotlinx-json:d9687dc")
+    implementation("com.github.holgerbrandl:jsonbuilder:0.10")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
     implementation("org.slf4j:slf4j-nop:2.0.5")
 }


### PR DESCRIPTION
This PR removes existing options used to set the parser's output format and location (`csv` and `compactJson`) in favour of a single unified set of options.

These two new options (`format` and `out-file`) can be used to achieve the same results as the previous methods, but allow for more flexibility in the future in terms of adding new output formats to help with automated parsing and importing of data.

The reason for me to implement this change in particular is a struggle I have encountered on mobilecombos.com where devices have data for LTE and ENDC, but not NR. In this case, it's not convenient to parse the CSV output from stdout since the importer cannot tell whether the 2nd CSV is NR SA capability data (like it would be on an SA-capable device) or ENDC data. This could be hard-coded by looking at the CSV header, but this raises other concerns for the future.

My proposed solution is a new `json-csv` output format which outputs a JSON string with up to three keys (`lte`, `endc`, `nr`) which each contain the standard CSV data that is normally output by the parser. This allows for an automated system, such as the mobilecombos importer, to easily parse the data as the correct RAT and import capability info into the database.

BREAKING CHANGE: The `csv` and `compactJson` options have been removed. Use the new `format` and `out-file` options instead.

For example `uecapabilityparser.jar -t Q -i b0cd.txt -c b0cd.csv` would now be `uecapabilityparser.jar -t Q -i b0cd.txt -f csv -o b0cd.csv`.