### PR TITLE
Bwstring: output both DL and UL bws

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/Utility.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/Utility.kt
@@ -536,17 +536,27 @@ object Utility {
     }
 
     fun ComponentNr.toBwString(): String {
-        val bws = if (isSUL) bandwidthsUL else bandwidthsDL
-        val bwString =
-            bws?.entries
+        val dlString =
+            bandwidthsDL
+                ?.entries
                 ?.filter { it.value.isNotEmpty() }
                 ?.joinToString(
-                    prefix = "[",
+                    prefix = "BwDL:[",
                     postfix = "]",
                     transform = { "${it.key}kHz: ${it.value.joinToString()}" },
                     separator = "; ",
                 )
-        return "n$band $bwString"
+        val ulString =
+            bandwidthsUL
+                ?.entries
+                ?.filter { it.value.isNotEmpty() }
+                ?.joinToString(
+                    prefix = "BwUL:[",
+                    postfix = "]",
+                    transform = { "${it.key}kHz: ${it.value.joinToString()}" },
+                    separator = "; ",
+                )
+        return "n$band $dlString $ulString"
     }
 
     private fun getResourceAsStream(path: String): InputStream? =

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/bean/nr/ComponentNr.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/bean/nr/ComponentNr.kt
@@ -82,8 +82,6 @@ data class ComponentNr(
         return str
     }
 
-    val isSUL: Boolean
-        get() = classUL <= '0'
     val isFR2: Boolean
         get() = band > 256
 }


### PR DESCRIPTION
The current implementation reports UL BWs for SDL combos and DL BWs for other combos.

First, the reporting of UL BWs for SDL bands was incorrect, but this was due to a bug in the ComponentNr#isSUL function.
Then some bands have different BWs between DL and UL.

So let's report both and fix both of issues.