### PR TITLE
Decouple kotlinversion used in normal build vs codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Edit kotlin version
+      run: sed -i 's/\(val kotlinVersion =\).*/\1 "1.8.0"/' build.gradle.kts
+
     - name: Setup jdk11
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
codeql don't add support for new versions of kotlin quickly enough