### PR TITLE
feat: add keyed json output option

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
@@ -17,6 +17,10 @@ object HelpMessage {
         """Output a csv, if "-" is the csv will be output to standard output.
         Some parsers output multiple CSVs, in these cases "-LTE", "-NR", "-EN-DC",
         "-NR-DC" will be added before the extension"""
+    const val KEYED_JSON =
+        """Output a JSON file containing an object that maps the appropriate RAT/capability type
+        to its respective capability data. E.g., { "lte": "combo;band1;..." }. If "-" is provided
+         in place of a file name, this will be outputted to standard output."""
     const val UE_LOG =
         """Output the uelog, if "-" is specified the uelog will be output to standard output"""
     const val DEBUG = "Print debug info"


### PR DESCRIPTION
Supercedes #6

This output format produces a JSON-compliant output containing an object that maps the capability type to its CSV data.

This makes it easier to handle the outputs from multiple parses (e.g., 0xB0CD plus 0xB826) and merge them together to allow for a simpler import process for a linked application.

This also prevents confusion between the various NR outputs (EN-DC, NR, NR-DC) as some devices may, for example, support NR SA but not ENDC, and currently there is no way for an automated process to determine which types of CSV have been outputted.

### Examples

```
java -jar uecapabilityparser.jar --type QNR --multiple0xB826 --keyed-json out2.json --input ./NR.txt
```

produced

```json
{
  "nr": "combo;NR DL1;NR BW1;NR SCS1;NR DL2;NR BW2;NR SCS2;NR DL3;NR BW3;NR SCS3;NR UL1;NR UL MOD1;NR UL2;NR UL MOD2;mimo NR DL1;mimo NR DL2;mimo NR DL3;mimo NR UL1;mimo NR UL2;BCS\nn79A4A-n78A4-n3A4;79A;100;30;78A;100;30;3A;40;15;79A;256qam;;;4;4;4;1;;\n...",
  "en-dc": "combo;DL1;DL2;DL3;DL4;DL5;UL1;MOD UL1;NR DL1;NR BW1;NR SCS1;NR DL2;NR BW2;NR SCS2;NR DL3;NR BW3;NR SCS3;NR DL4;NR BW4;NR SCS4;NR DL5;NR BW5;NR SCS5;NR UL1;NR UL MOD1;mimo DL1;mimo DL2;mimo DL3;mimo DL4;mimo DL5;mimo NR DL1;mimo NR DL2;mimo NR DL3;mimo NR DL4;mimo NR DL5;mimo LTE UL1;mimo NR UL1;BCS NR;BCS LTE;BCS intraENDC\n66A2A-66A2-13A2-2A2_n261H2H2-n261G2-n261A2;66A;66A;13A;2A;;66A;256qam;261H;100;120;261G;100;120;261A;100;120;;;;;;;261H;256qam;2;2;2;2;;2;2;2;;;1;2;;;\n...",
  "nr-dc": "combo;FR1 DL1;FR1 BW1;FR1 SCS1;FR2 DL1;FR2 BW1;FR2 SCS1;FR2 DL2;FR2 BW2;FR2 SCS2;FR2 DL3;FR2 BW3;FR2 SCS3;FR1 UL1;FR1 UL MOD1;FR2 UL1;FR2 UL MOD1;mimo FR1 DL1;mimo FR2 DL1;mimo FR2 DL2;mimo FR2 DL3;mimo FR1 UL1;mimo FR2 UL1;BCS\nn77A4A_n261I2I2-n261G2-n261A2;77A;100;30;261I;100;120;261G;100;120;261A;100;120;77A;256qam;261I;256qam;4;2;2;2;1;2;\n..."
}

```

---

```
java -jar uecapabilityparser.jar --type Q --keyed-json out.json --input ./LTE.txt 
```

```json
{
  "lte": "combo;band1;band2;band3;band4;band5;class1;class2;class3;class4;class5;mimo1;mimo2;mimo3;mimo4;mimo5;ul1;ul2;ul3;ul4;ul5;ULmimo1;ULmimo2;ULmimo3;ULmimo4;ULmimo5;DLmod1;DLmod2;DLmod3;DLmod4;DLmod5;ULmod1;ULmod2;ULmod3;ULmod4;ULmod5;bsc\n71A2A-66A4-66A4-2A4;71;66;66;2;;A;A;A;A;;2;4;4;4;;A;;;;;1;;;;;;;;;;256qam;;;;;\n71A2-66A4A-66A4-2A4;71;66;66;2;;A;A;A;A;;2;4;4;4;;;A;;;;;1;;;;;;;;;;256qam;;;;\n71A2-66A4-66A4-2A4A;71;66;66;2;;A;A;A;A;;2;4;4;4;;;;;A;;;;;1;;;;;;;;;;256qam;;\n71A2A-66A4-66A4;71;66;66;;;A;A;A;;;2;4;4;;;A;;;;;1;;;;;;;;;;256qam;;;;;\n71A2-66A4A-66A4;71;66;66;;;A;A;A;;;2;4;4;;;;A;;;;;1;;;;;;;;;;256qam;;;;\n..."
}
```