### PR TITLE
MixedMimo: use list instead of array

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/importer/Import0xB0CD.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/importer/Import0xB0CD.kt
@@ -204,8 +204,7 @@ object Import0xB0CD : ImportCapabilities {
         if (value.isEmpty() || value.endsWith("INVALID_INDEX")) {
             return EmptyMimo
         }
-        val mimoArray =
-            value.split('_').drop(2).dropLast(1).mapNotNull(String::toIntOrNull).toIntArray()
+        val mimoArray = value.split('_').drop(2).dropLast(1).mapNotNull(String::toIntOrNull)
         return Mimo.from(mimoArray)
     }
 

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/importer/Import0xB826.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/importer/Import0xB826.kt
@@ -421,7 +421,7 @@ object Import0xB826 : ImportCapabilities {
             }
         }
 
-        val resultMimo = Mimo.from(result)
+        val resultMimo = Mimo.from(result.toList())
         cacheMimoIndex[index] = resultMimo
 
         return resultMimo

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformation.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformation.kt
@@ -753,7 +753,7 @@ object ImportCapabilityInformation : ImportCapabilities {
 
         if (!dlFeature.isNullOrEmpty()) {
             if (dlFeature.size > 1 && dlFeature.distinct().size > 1) {
-                val mixedMimo = dlFeature.map { it.mimo.average().toInt() }.toIntArray()
+                val mixedMimo = dlFeature.map { it.mimo.average().toInt() }
                 componentLte.mimoDL = Mimo.from(mixedMimo)
             } else {
                 componentLte.mimoDL = dlFeature.first().mimo
@@ -766,7 +766,7 @@ object ImportCapabilityInformation : ImportCapabilities {
 
         if (!ulFeature.isNullOrEmpty()) {
             if (ulFeature.size > 1 && ulFeature.distinct().size > 1) {
-                val mixedMimo = ulFeature.map { it.mimo.average().toInt() }.toIntArray()
+                val mixedMimo = ulFeature.map { it.mimo.average().toInt() }
                 componentLte.mimoUL = Mimo.from(mixedMimo)
             } else {
                 componentLte.mimoUL = ulFeature.first().mimo
@@ -790,7 +790,7 @@ object ImportCapabilityInformation : ImportCapabilities {
         if (!dlFeature.isNullOrEmpty()) {
             val firstFeature = dlFeature.first()
             if (dlFeature.size > 1 && dlFeature.distinct().size > 1) {
-                val mixedMimo = dlFeature.map { it.mimo.average().toInt() }.toIntArray()
+                val mixedMimo = dlFeature.map { it.mimo.average().toInt() }
                 componentNr.mimoDL = Mimo.from(mixedMimo)
             } else {
                 componentNr.mimoDL = firstFeature.mimo
@@ -808,7 +808,7 @@ object ImportCapabilityInformation : ImportCapabilities {
 
         if (!ulFeature.isNullOrEmpty()) {
             if (ulFeature.size > 1 && ulFeature.distinct().size > 1) {
-                val mixedMimo = ulFeature.map { it.mimo.average().toInt() }.toIntArray()
+                val mixedMimo = ulFeature.map { it.mimo.average().toInt() }
                 componentNr.mimoUL = Mimo.from(mixedMimo)
             } else {
                 componentNr.mimoUL = ulFeature.first().mimo
@@ -1316,7 +1316,7 @@ object ImportCapabilityInformation : ImportCapabilities {
             }
 
         // Don't override mimo if all are = to default
-        return if (allDefault) defaultMimo else Mimo.from(mixedMimoList.toIntArray())
+        return if (allDefault) defaultMimo else Mimo.from(mixedMimoList)
     }
 
     private fun parseBandParametersUL(

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportNvItem.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportNvItem.kt
@@ -119,7 +119,7 @@ object ImportNvItem : ImportCapabilities {
                             list.add(antSubCC)
                         }
                     }
-                    Mimo.from(list.toIntArray())
+                    Mimo.from(list)
                 }
 
             if (band == 0) {

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/model/Mimo.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/model/Mimo.kt
@@ -9,7 +9,7 @@ sealed interface Mimo : Comparable<Mimo> {
 
     companion object {
         private val cacheInt = WeakHashMap<Int, Mimo>()
-        private val cacheIntArray = WeakHashMap<IntArray, Mimo>()
+        private val cacheIntArray = WeakHashMap<List<Int>, Mimo>()
 
         fun from(int: Int): Mimo {
             val cachedResult = cacheInt[int]
@@ -21,7 +21,7 @@ sealed interface Mimo : Comparable<Mimo> {
                 if (int == 0) {
                     EmptyMimo
                 } else if (int > 10) {
-                    from(int.toString().map(Char::digitToInt).toIntArray())
+                    from(int.toString().map(Char::digitToInt))
                 } else {
                     SingleMimo(int)
                 }
@@ -30,22 +30,22 @@ sealed interface Mimo : Comparable<Mimo> {
             return result
         }
 
-        fun from(intArray: IntArray): Mimo {
-            val cachedResult = cacheIntArray[intArray]
+        fun from(list: List<Int>): Mimo {
+            val cachedResult = cacheIntArray[list]
             if (cachedResult != null) {
                 return cachedResult
             }
 
             val result =
-                if (intArray.isEmpty()) {
+                if (list.isEmpty()) {
                     EmptyMimo
-                } else if (intArray.size == 1 || intArray.distinct().count() == 1) {
-                    SingleMimo(intArray.first())
+                } else if (list.size == 1 || list.distinct().count() == 1) {
+                    SingleMimo(list.first())
                 } else {
-                    MixedMimo(intArray.sortedArrayDescending())
+                    MixedMimo(list.sortedDescending())
                 }
 
-            cacheIntArray[intArray] = result
+            cacheIntArray[list] = result
             return result
         }
     }
@@ -63,19 +63,10 @@ private data class SingleMimo(private val mimo: Int) : Mimo {
     override fun average(): Double = mimo.toDouble()
 }
 
-private data class MixedMimo(private val mimoArray: IntArray) : Mimo {
-    override fun toCompactStr(): String = mimoArray.joinToString("")
-    override fun toString(): String = mimoArray.joinToString(", ")
-    override fun average(): Double = mimoArray.average()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is MixedMimo) return false
-
-        return mimoArray.contentEquals(other.mimoArray)
-    }
-
-    override fun hashCode(): Int = mimoArray.contentHashCode()
+private data class MixedMimo(private val mimoList: List<Int>) : Mimo {
+    override fun toCompactStr(): String = mimoList.joinToString("")
+    override fun toString(): String = mimoList.joinToString(", ")
+    override fun average(): Double = mimoList.average()
 }
 
 fun Int.toMimo(): Mimo = Mimo.from(this)


### PR DESCRIPTION
Two arrays with the same elements aren't equal, so arrays cannot be used as maps key.