### PR TITLE
MtsAsn1Helpers: store parse tree in lazy properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    val mtsAsn1Version = "0.0.8"
+    val mtsAsn1Version = "7bdf0d8"
     val kmemVersion = "3.4.0"
     val javalinVersion = "5.4.2"
 


### PR DESCRIPTION
With this change, each asn definition is parsed at most once. Each parsing tree occupies ~30MB of heap memory.