### PR TITLE
docker: tune gc jvm options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ COPY --from=build /home/gradle/build/libs/*-all.jar /app/uecapabilityparser.jar
 
 USER java
 WORKDIR /home/java
+ENV JAVA_TOOL_OPTIONS -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahUncommitDelay=30000 -XX:ShenandoahGuaranteedGCInterval=60000
 
 ENTRYPOINT [ "java", "-jar", "/app/uecapabilityparser.jar" ]


### PR DESCRIPTION
use ShenandoahGC (concurrent gc) with more aggresive defaults to release resources quickly. Also limit max heap memory to 512MB to avoid allocating 1 GB or more when parsing several capabilities simultaneously