### PR TITLE
Implement cli and server mode as clikt subcommands

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.Option
 import com.github.ajalt.clikt.parameters.options.OptionDelegate
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.deprecated
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -202,11 +203,18 @@ object Cli :
 object Server : CliktCommand(name = "server", help = "Starts ue capability parser in server mode") {
     private const val DEFAULT_PORT = 8080
 
+    private val port by
+        option("-p", "--port", help = HelpMessage.PORT, metavar = "PORT")
+            .int()
+            .default(DEFAULT_PORT)
+
+    // -p/--port was -s/--server in 0.1.0
     private val server by
         option("-s", "--server", help = HelpMessage.SERVER, metavar = "PORT")
             .int()
             .optionalValue(DEFAULT_PORT)
-            .required()
+            .default(DEFAULT_PORT, defaultForHelp = "")
+            .deprecated("WARNING: option --server is deprecated, use --port instead", "")
 
     private val store by option("--store", help = HelpMessage.STORE, metavar = "DIR")
 
@@ -226,7 +234,7 @@ object Server : CliktCommand(name = "server", help = "Starts ue capability parse
         }
 
         // Start server
-        val serverPort = server
+        val serverPort = if (port != DEFAULT_PORT) port else server
         ServerMode.run(serverPort)
 
         val serverStartMessage = "Server started at port $serverPort$debugMessage$storeMessage"

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
@@ -22,7 +22,7 @@ import it.smartphonecombo.uecapabilityparser.util.Property
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-object Clikt : CliktCommand(name = "UE Capability Parser", printHelpOnEmptyArgs = true) {
+object Clikt : CliktCommand(name = "uecapabilityparser", printHelpOnEmptyArgs = true) {
     init {
         versionOption(version = Property.getProperty("project.version") ?: "")
     }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
@@ -223,21 +223,18 @@ object Server : CliktCommand(name = "server", help = "Starts ue capability parse
     override fun run() {
         // Set debug if it's passed to subcommand
         if (debug) Config["debug"] = debug.toString()
-        val isDebug = Config["debug"].toBoolean()
-        val debugMessage = if (isDebug) " with debug enabled" else ""
 
         // Process store
-        var storeMessage = ""
-        store?.let {
-            Config["store"] = it
-            storeMessage = if (isDebug) " and with store enabled" else " with store enabled"
-        }
+        store?.let { Config["store"] = it }
 
         // Start server
         val serverPort = if (port != DEFAULT_PORT) port else server
         ServerMode.run(serverPort)
 
-        val serverStartMessage = "Server started at port $serverPort$debugMessage$storeMessage"
+        echo(buildServerStartMessage(serverPort))
+    }
+
+    private fun buildServerStartMessage(serverPort: Int): String {
         val webUiMessage =
             """
             |Web UI (demo) available at http://localhost:$serverPort/
@@ -246,6 +243,15 @@ object Server : CliktCommand(name = "server", help = "Starts ue capability parse
             """
                 .trimMargin()
 
-        echo("$serverStartMessage\n$webUiMessage")
+        val features = mutableListOf<String>()
+        if (Config["debug"].toBoolean()) features += "debug"
+        if (store != null) features += "store"
+
+        val featuresString =
+            if (features.isNotEmpty()) {
+                features.joinToString(" and ", " with ", " enabled")
+            } else ""
+
+        return "Server started at port $serverPort$featuresString\n$webUiMessage"
     }
 }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Clikt.kt
@@ -1,7 +1,9 @@
 package it.smartphonecombo.uecapabilityparser.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.output.MordantHelpFormatter
 import com.github.ajalt.clikt.parameters.options.Option
 import com.github.ajalt.clikt.parameters.options.OptionDelegate
 import com.github.ajalt.clikt.parameters.options.default
@@ -51,6 +53,13 @@ object Clikt :
             if (cmdName == "cli") oldCliOptions = opt else oldServerOptions = opt
 
             registerOption(opt)
+        }
+
+        // Customize help formatter
+        context {
+            helpFormatter = {
+                MordantHelpFormatter(it, showDefaultValues = true, requiredOptionMarker = "*")
+            }
         }
     }
 

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
@@ -25,8 +25,6 @@ object HelpMessage {
     const val JSON =
         """Output a JSON file representing the serialization of capabilities data.
          If "-" is provided in place of a file name, this will json be outputted to standard output."""
-    const val SERVER =
-        """Starts ue capability parser in server mode, accepting requests to the port passed as value. If no value passed default to 8080."""
-    const val STORE =
-        "Store the capabilities in the given directory for further retrieval. Only applicable to server mode."
+    const val SERVER = """Listen to the port passed as value"""
+    const val STORE = "Store the capabilities in the given directory for further retrieval"
 }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/HelpMessage.kt
@@ -25,6 +25,7 @@ object HelpMessage {
     const val JSON =
         """Output a JSON file representing the serialization of capabilities data.
          If "-" is provided in place of a file name, this will json be outputted to standard output."""
-    const val SERVER = """Listen to the port passed as value"""
+    const val PORT = """Listen to the port passed as value"""
+    const val SERVER = """Same as --port but deprecated"""
     const val STORE = "Store the capabilities in the given directory for further retrieval"
 }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Main.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/cli/Main.kt
@@ -1,30 +1,8 @@
 package it.smartphonecombo.uecapabilityparser.cli
 
-import com.github.ajalt.clikt.core.CliktError
-import com.github.ajalt.clikt.core.PrintMessage
-import com.github.ajalt.clikt.core.UsageError
-import com.github.ajalt.clikt.output.ParameterFormatter
-
 internal object Main {
     @JvmStatic
     fun main(args: Array<String>) {
-        // If args contains server, use Clikt.parse to avoid System.exit() for exceptions
-        if (args.contains("-s") || args.contains("--server")) {
-            try {
-                Clikt.parse(args)
-            } catch (e: PrintMessage) {
-                println(e.message)
-            } catch (e: UsageError) {
-                val context = e.context ?: Clikt.currentContext
-                // Take only the first line
-                val message =
-                    e.formatMessage(context.localization, ParameterFormatter.Plain).lines().first()
-                System.err.println(message)
-            } catch (e: CliktError) {
-                System.err.println(e.message)
-            }
-        } else {
-            Clikt.main(args)
-        }
+        Clikt.main(args)
     }
 }


### PR DESCRIPTION
- cli mode options are moved to `cli` command, server mode options to `server` command
- uecapabilityparser will continue to run without specifying the command, but this mode is deprecated
- `--server` option is no longer mandatory (for server mode) and is deprecated, its replacement is `--port` which has a better name and a non-optional value.
- help output now includes default values and required options

This is the updated help output:
<details>
<summary>help output</summary>

```
$ uecapabilityparser -h
Usage: uecapabilityparser [<options>] <command> [<args>]...

Options:
  --version   Show the version and exit
  -h, --help  Show this message and exit

Commands:
  cli     Starts ue capability parser in cli mode
  server  Starts ue capability parser in server mode
```
```
$ uecapabilityparser server -h
Usage: uecapabilityparser server [<options>]

  Starts ue capability parser in server mode

Options:
  -p, --port=<port>      Listen to the port passed as value (default: 8080)
  -s, --server[=<port>]  Same as --port but deprecated
  --store=<dir>          Store the capabilities in the given directory for
                         further retrieval
  -d, --debug            Print debug info
  -h, --help             Show this message and exit
```
```
$ uecapabilityparser cli -h
Usage: uecapabilityparser cli [<options>]

  Starts ue capability parser in cli mode

Options:
* -i, --input=<file>         UE Capability Parser
  --inputNR=<file>           NR UE Capability file
  --inputENDC=<file>         ENDC UE Capability file
  --nr, --defaultNR          Main capability input is NR (otherwise LTE)
  --multi, --multiple0xB826  Use this option if input contains several 0xB0CD
                             or 0xB826 hexdumps separated by blank lines and/or
                             prefixed with "Payload :", "CA Combos RAW:" or
                             "0x9801" (option deprecated, default behaviour)
* -t, --type=(H|W|N|C|CNR|E|Q|QLTE|QNR|M|O|QC|RF)
                             Type of capability. Valid values are: H (UE
                             Capability Hex Dump), W (Wireshark UE Capability
                             Information), N (NSG UE Capability Information), C
                             (Carrier policy), CNR (NR Cap Prune), E (28874
                             nvitem binary, decompressed), Q (QCAT 0xB0CD),
                             QLTE (0xB0CD hexdump), QNR (0xB826 hexdump), M
                             (MEDIATEK CA_COMB_INFO), O (OSIX UE Capability
                             Information), QC (QCAT UE Capability Information),
                             RF (QCT Modem Capabilities)
  -c, --csv=<file>           Output a csv, if "-" is the csv will be output to
                             standard output. Some parsers output multiple
                             CSVs, in these cases "-LTECA", "-NRCA", "-ENDC",
                             "-NRDC" will be added before the extension
  -j, --json=<file>          Output a JSON file representing the serialization
                             of capabilities data. If "-" is provided in place
                             of a file name, this will json be outputted to
                             standard output.
  --json-pretty-print        Specifies whether resulting JSONs should be
                             pretty-printed
  -l, --uelog=<file>         Output the uelog, if "-" is specified the uelog
                             will be output to standard output
  -d, --debug                Print debug info
  -h, --help                 Show this message and exit
```
</details>