### PR TITLE
Improve server mode efficiency

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/extension/Context.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/extension/Context.kt
@@ -1,8 +1,12 @@
 package it.smartphonecombo.uecapabilityparser.extension
 
+import io.javalin.config.SizeUnit
 import io.javalin.http.ContentType
 import io.javalin.http.Context
 import io.javalin.http.HttpStatus
+import io.javalin.http.bodyAsClass
+import io.javalin.http.bodyStreamAsClass
+import io.javalin.http.servlet.throwContentTooLargeIfContentTooLarge
 
 internal fun Context.badRequest(message: String = "Bad Request") {
     result(message)
@@ -24,4 +28,18 @@ internal fun Context.attachFile(data: ByteArray, filename: String, contentType: 
         .contentType(contentType)
         .header("Content-Disposition", "attachment; filename=$filename")
         .header("Access-Control-Expose-Headers", "Content-Disposition")
+}
+
+/**
+ * Use bodyStreamAsClass for body > 1MiB, bodyAsClass for body <= 1MiB.
+ *
+ * Throw ContentTooLarge if content size is above max size.
+ */
+internal inline fun <reified T : Any> Context.bodyAsClassEfficient(): T {
+    throwContentTooLargeIfContentTooLarge()
+    return if (req().contentLengthLong > SizeUnit.MB.multiplier) {
+        bodyStreamAsClass<T>()
+    } else {
+        bodyAsClass<T>()
+    }
 }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/extension/JsonElement.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/extension/JsonElement.kt
@@ -34,7 +34,3 @@ internal fun JsonElement.asIntOrNull(): Int? {
 internal fun JsonElement.asArrayOrNull(): JsonArray? {
     return this as? JsonArray
 }
-
-internal fun JsonElement.getStringList(key: String): List<String>? {
-    return this.getArray(key)?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
-}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/model/Serializers.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/model/Serializers.kt
@@ -1,0 +1,24 @@
+package it.smartphonecombo.uecapabilityparser.model
+
+import java.util.Base64
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ByteArrayBase64Serializer : KSerializer<ByteArray> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("ByteArrayBase64", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ByteArray) {
+        val string = Base64.getEncoder().encodeToString(value)
+        encoder.encodeString(string)
+    }
+
+    override fun deserialize(decoder: Decoder): ByteArray {
+        val string = decoder.decodeString()
+        return Base64.getDecoder().decode(string)
+    }
+}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
@@ -122,12 +122,15 @@ class JavalinApp {
                 }
             }
             apiBuilderPost("/parse/multi") { ctx ->
-                val request = Json.parseToJsonElement(ctx.body())
-                val parsed =
-                    MultiParsing.fromJsonRequest(request) ?: return@apiBuilderPost ctx.badRequest()
-                ctx.json(parsed.getMultiCapabilities())
-                if (store != null) {
-                    parsed.store(index, store, compression)
+                try {
+                    val request = ctx.bodyAsClass<List<RequestMultiParse>>()
+                    val parsed = MultiParsing.fromRequest(request)!!
+                    ctx.json(parsed.getMultiCapabilities())
+                    if (store != null) {
+                        parsed.store(index, store, compression)
+                    }
+                } catch (_: Exception) {
+                    return@apiBuilderPost ctx.badRequest()
                 }
             }
             apiBuilderPost("/csv", "/csv/0.1.0") { ctx ->

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
@@ -7,11 +7,11 @@ import io.javalin.http.ContentType
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.HttpStatus
-import io.javalin.http.bodyStreamAsClass
 import io.javalin.http.staticfiles.Location
 import io.javalin.json.JsonMapper
 import it.smartphonecombo.uecapabilityparser.extension.attachFile
 import it.smartphonecombo.uecapabilityparser.extension.badRequest
+import it.smartphonecombo.uecapabilityparser.extension.bodyAsClassEfficient
 import it.smartphonecombo.uecapabilityparser.extension.custom
 import it.smartphonecombo.uecapabilityparser.extension.internalError
 import it.smartphonecombo.uecapabilityparser.extension.mutableListWithCapacity
@@ -120,7 +120,7 @@ class JavalinApp {
 
             apiBuilderPost("/parse", "/parse/0.1.0") { ctx ->
                 try {
-                    val request = ctx.bodyStreamAsClass<RequestParse>()
+                    val request = ctx.bodyAsClassEfficient<RequestParse>()
                     val parsed = Parsing.fromRequest(request)!!
                     ctx.json(parsed.capabilities)
                     if (store != null) {
@@ -132,7 +132,7 @@ class JavalinApp {
             }
             apiBuilderPost("/parse/multi") { ctx ->
                 try {
-                    val request = ctx.bodyStreamAsClass<List<RequestMultiParse>>()
+                    val request = ctx.bodyAsClassEfficient<List<RequestMultiParse>>()
                     val parsed = MultiParsing.fromRequest(request)!!
                     ctx.json(parsed.getMultiCapabilities())
                     if (store != null) {
@@ -144,7 +144,7 @@ class JavalinApp {
             }
             apiBuilderPost("/csv", "/csv/0.1.0") { ctx ->
                 try {
-                    val request = ctx.bodyStreamAsClass<RequestCsv>()
+                    val request = ctx.bodyAsClassEfficient<RequestCsv>()
                     val comboList = request.input
                     val type = request.type
                     val date = dataFormatter.format(ZonedDateTime.now(ZoneOffset.UTC))

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
@@ -1,0 +1,33 @@
+package it.smartphonecombo.uecapabilityparser.server
+
+import it.smartphonecombo.uecapabilityparser.model.combo.ComboEnDc
+import it.smartphonecombo.uecapabilityparser.model.combo.ComboLte
+import it.smartphonecombo.uecapabilityparser.model.combo.ComboNr
+import it.smartphonecombo.uecapabilityparser.model.combo.ComboNrDc
+import it.smartphonecombo.uecapabilityparser.model.combo.ICombo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface RequestCsv {
+    val input: List<ICombo>
+    val type
+        get() = javaClass.simpleName.lowercase()
+
+    @Serializable
+    @SerialName("lteca")
+    data class LteCa(override val input: List<ComboLte>) : RequestCsv
+
+    @Serializable
+    @SerialName("nrca")
+    data class NrCa(override val input: List<ComboNr>) : RequestCsv
+
+    @Serializable
+    @SerialName("nrdc")
+    data class NrDc(override val input: List<ComboNrDc>) : RequestCsv
+
+    @Serializable
+    @SerialName("endc")
+    data class EnDc(override val input: List<ComboEnDc>) : RequestCsv
+}
+

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
@@ -1,5 +1,7 @@
 package it.smartphonecombo.uecapabilityparser.server
 
+import it.smartphonecombo.uecapabilityparser.model.ByteArrayBase64Serializer
+import it.smartphonecombo.uecapabilityparser.model.LogType
 import it.smartphonecombo.uecapabilityparser.model.combo.ComboEnDc
 import it.smartphonecombo.uecapabilityparser.model.combo.ComboLte
 import it.smartphonecombo.uecapabilityparser.model.combo.ComboNr
@@ -31,3 +33,28 @@ sealed interface RequestCsv {
     data class EnDc(override val input: List<ComboEnDc>) : RequestCsv
 }
 
+@Serializable
+class RequestParse(
+    @Serializable(with = ByteArrayBase64Serializer::class) val input: ByteArray? = null,
+    @Serializable(with = ByteArrayBase64Serializer::class) val inputNR: ByteArray? = null,
+    @Serializable(with = ByteArrayBase64Serializer::class) val inputENDC: ByteArray? = null,
+    val defaultNR: Boolean = false,
+    val type: LogType,
+    val description: String = ""
+) {
+    companion object {
+        fun buildRequest(
+            vararg inputs: ByteArray,
+            type: LogType,
+            description: String,
+            defaultNR: Boolean
+        ): RequestParse {
+            val input = inputs.firstOrNull()
+            val firstInputIsNr = type == LogType.H && defaultNR
+            val inputNR = if (firstInputIsNr) null else inputs.getOrNull(1)
+            val inputENDC = if (firstInputIsNr) inputs.getOrNull(1) else inputs.getOrNull(2)
+
+            return RequestParse(input, inputNR, inputENDC, defaultNR, type, description)
+        }
+    }
+}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
@@ -58,3 +58,11 @@ class RequestParse(
         }
     }
 }
+
+@Serializable
+class RequestMultiParse(
+    val inputs: List<@Serializable(with = ByteArrayBase64Serializer::class) ByteArray>,
+    val type: LogType,
+    val subTypes: List<String> = emptyList(),
+    val description: String = ""
+)

--- a/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
+++ b/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
@@ -4,6 +4,9 @@ import dev.adamko.kxstsgen.KxsTsGenerator
 import it.smartphonecombo.uecapabilityparser.model.Capabilities
 import it.smartphonecombo.uecapabilityparser.model.MultiCapabilities
 import it.smartphonecombo.uecapabilityparser.model.index.LibraryIndex
+import it.smartphonecombo.uecapabilityparser.server.RequestCsv
+import it.smartphonecombo.uecapabilityparser.server.RequestMultiParse
+import it.smartphonecombo.uecapabilityparser.server.RequestParse
 import it.smartphonecombo.uecapabilityparser.server.ServerStatus
 import it.smartphonecombo.uecapabilityparser.util.IO
 
@@ -24,7 +27,10 @@ internal object TsTypesGenerator {
                 Capabilities.serializer(),
                 LibraryIndex.serializer(),
                 MultiCapabilities.serializer(),
-                ServerStatus.serializer()
+                ServerStatus.serializer(),
+                RequestCsv.serializer(),
+                RequestParse.serializer(),
+                RequestMultiParse.serializer()
             )
         IO.outputFileOrStdout(warning + typescriptDefinitions, "uecapabilityparser.d.ts")
         println("Typescript definitions exported to uecapabilityparser.d.ts")


### PR DESCRIPTION
Improve overall server mode performance and efficiency by:
- Using Data classes instead of JsonElements
- Avoiding base64 encoding and decoding in reparse
- Using inputStream instead of String for requests above 1MB