### PR TITLE
Add a multipart version of /parse/multi endpoint

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Requests.kt
@@ -1,5 +1,6 @@
 package it.smartphonecombo.uecapabilityparser.server
 
+import io.javalin.http.UploadedFile
 import it.smartphonecombo.uecapabilityparser.model.ByteArrayBase64Serializer
 import it.smartphonecombo.uecapabilityparser.model.LogType
 import it.smartphonecombo.uecapabilityparser.model.combo.ComboEnDc
@@ -66,3 +67,17 @@ class RequestMultiParse(
     val subTypes: List<String> = emptyList(),
     val description: String = ""
 )
+
+@Serializable
+class RequestMultiPart(
+    val inputIndexes: List<Int>,
+    val type: LogType,
+    val subTypes: List<String> = emptyList(),
+    val description: String = ""
+) {
+    fun toRequestMultiParse(files: List<UploadedFile>): RequestMultiParse {
+        val newInputs =
+            inputIndexes.map { index -> files[index].contentAndClose { it.readAllBytes() } }
+        return RequestMultiParse(newInputs, type, subTypes, description)
+    }
+}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/util/MultiParsing.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/util/MultiParsing.kt
@@ -137,7 +137,7 @@ class MultiParsing(
 
                 inputsList.add(inputs)
                 typeList.add(type)
-                subTypesList.add(subTypes)
+                if (type == LogType.H) subTypesList.add(subTypes)
                 descriptionList.add(description.trim())
             }
 

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/UtilityForTests.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/UtilityForTests.kt
@@ -6,6 +6,12 @@ import java.nio.file.Path
 import java.util.stream.Collectors
 import kotlin.io.path.Path
 import kotlin.math.abs
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import okhttp3.MultipartBody
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
 
 object UtilityForTests {
 
@@ -58,5 +64,24 @@ object UtilityForTests {
         } catch (ignored: Exception) {
             false
         }
+    }
+
+    internal fun multiPartRequest(url: String, json: JsonElement, files: List<String>): Request {
+
+        val bodyBuilder =
+            MultipartBody.Builder().apply {
+                setType(MultipartBody.FORM)
+                addFormDataPart("requests", Json.encodeToString(json))
+                files.forEach {
+                    val file = File(it)
+                    addFormDataPart("file", file.name, file.asRequestBody())
+                }
+            }
+        val reqBuilder =
+            Request.Builder().apply {
+                url(url)
+                post(bodyBuilder.build())
+            }
+        return reqBuilder.build()
     }
 }

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
@@ -1,0 +1,409 @@
+package it.smartphonecombo.uecapabilityparser.server
+
+import io.javalin.http.HttpStatus
+import io.javalin.testtools.JavalinTest
+import it.smartphonecombo.uecapabilityparser.UtilityForTests
+import it.smartphonecombo.uecapabilityparser.UtilityForTests.multiPartRequest
+import it.smartphonecombo.uecapabilityparser.extension.custom
+import it.smartphonecombo.uecapabilityparser.model.MultiCapabilities
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+
+internal class ServerModeMultiPartParseTest {
+    private val inputPath = "src/test/resources/mainCli/input/"
+    private val oraclePath = "src/test/resources/server/oracleForMultiParse/"
+    private val app = JavalinApp().app
+    private val endpoint = arrayOf("/parse/multiPart", "/parse/multiPart/").random()
+
+    @Test
+    fun carrierPolicy() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "C")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/carrierPolicy.xml"),
+            oraclePath = "$oraclePath/carrierPolicy.json",
+        )
+    }
+
+    @Test
+    fun b0CDText() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "Q")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/0xB0CD.txt"),
+            oraclePath = "$oraclePath/0xB0CD.json",
+        )
+    }
+
+    @Test
+    fun b0CDMultiHex() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "QLTE")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/0xB0CDMultiHex.txt"),
+            oraclePath = "$oraclePath/0xB0CDMultiHex.json",
+        )
+    }
+
+    @Test
+    fun mtkLte() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "M")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/mtkLte.txt"),
+            oraclePath = "$oraclePath/mtkLte.json",
+        )
+    }
+
+    @Test
+    fun nvItem() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "E")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/nvItem.bin"),
+            oraclePath = "$oraclePath/nvItem.json",
+        )
+    }
+
+    @Test
+    fun b826Multi() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "QNR")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/0xB826Multi.txt"),
+            oraclePath = "$oraclePath/0xB826Multi.json",
+        )
+    }
+
+    @Test
+    fun nrCapPrune() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "CNR")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/nrCapPrune.txt"),
+            oraclePath = "$oraclePath/nrCapPrune.json",
+        )
+    }
+
+    @Test
+    fun qctModemCap() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "RF")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/qctModemCap.txt"),
+            oraclePath = "$oraclePath/qctModemCap.json",
+        )
+    }
+
+    @Test
+    fun wiresharkMrdcSplit() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "W")
+                        putJsonArray("inputIndexes") {
+                            add(0)
+                            add(1)
+                        }
+                    }
+                },
+            files =
+                listOf(
+                    "$inputPath/wiresharkMrdcSplit_0.txt",
+                    "$inputPath/wiresharkMrdcSplit_1.txt"
+                ),
+            oraclePath = "$oraclePath/wiresharkMrdcSplit.json",
+        )
+    }
+
+    @Test
+    fun nsgMrdcSplit() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "N")
+                        putJsonArray("inputIndexes") {
+                            add(0)
+                            add(1)
+                        }
+                    }
+                },
+            files = listOf("$inputPath/nsgMrdcSplit_0.txt", "$inputPath/nsgMrdcSplit_1.txt"),
+            oraclePath = "$oraclePath/nsgMrdcSplit.json",
+        )
+    }
+
+    @Test
+    fun osixMrdc() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "O")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/osixMrdc.txt"),
+            oraclePath = "$oraclePath/osixMrdc.json",
+        )
+    }
+
+    @Test
+    fun ueCapHexEutra() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "H")
+                        putJsonArray("inputIndexes") { add(0) }
+                        putJsonArray("subTypes") { add("LTE") }
+                    }
+                },
+            files = listOf("$inputPath/ueCapHexEutra.hex"),
+            oraclePath = "$oraclePath/ueCapHexEutra.json",
+        )
+    }
+
+    @Test
+    fun ueCapHexNr() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "H")
+                        putJsonArray("inputIndexes") { add(0) }
+                        putJsonArray("subTypes") { add("NR") }
+                    }
+                },
+            files = listOf("$inputPath/ueCapHexNr.hex"),
+            oraclePath = "$oraclePath/ueCapHexNr.json",
+        )
+    }
+
+    @Test
+    fun ueCapHexMrdcSplit() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "H")
+                        putJsonArray("inputIndexes") {
+                            add(0)
+                            add(1)
+                            add(2)
+                        }
+                        putJsonArray("subTypes") {
+                            add("ENDC")
+                            add("NR")
+                            add("LTE")
+                        }
+                    }
+                },
+            files =
+                listOf(
+                    "$inputPath/ueCapHexMrdcSplit_eutra-nr.hex",
+                    "$inputPath/ueCapHexMrdcSplit_nr.hex",
+                    "$inputPath/ueCapHexMrdcSplit_eutra.hex"
+                ),
+            oraclePath = "$oraclePath/ueCapHexMrdcSplit.json",
+        )
+    }
+
+    @Test
+    fun qcatNrdc() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "QC")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/qcatNrdc.txt"),
+            oraclePath = "$oraclePath/qcatNrdc.json",
+        )
+    }
+
+    @Test
+    fun carrierPolicyAndNrCapPrune() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "C")
+                        putJsonArray("inputIndexes") { add(1) }
+                    }
+                    addJsonObject {
+                        put("type", "CNR")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/nrCapPrune.txt", "$inputPath/carrierPolicy.xml"),
+            oraclePath = "$oraclePath/carrierPolicyAndNrCapPrune.json",
+        )
+    }
+
+    @Test
+    fun b0CDMultiHexAndB826Multi() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "QLTE")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                    addJsonObject {
+                        put("type", "QNR")
+                        putJsonArray("inputIndexes") { add(1) }
+                    }
+                },
+            files = listOf("$inputPath/0xB0CDMultiHex.txt", "$inputPath/0xB826Multi.txt"),
+            oraclePath = "$oraclePath/0xB0CDMultiHexAnd0xB826Multi.json",
+        )
+    }
+
+    @Test
+    fun nvItemQctModemCap() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "E")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                    addJsonObject {
+                        put("type", "RF")
+                        putJsonArray("inputIndexes") { add(1) }
+                    }
+                },
+            files = listOf("$inputPath/nvItem.bin", "$inputPath/qctModemCap.txt"),
+            oraclePath = "$oraclePath/nvItemAndQctModemCap.json",
+        )
+    }
+
+    @Test
+    fun pcap() {
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "P")
+                        putJsonArray("inputIndexes") { add(0) }
+                    }
+                },
+            files = listOf("$inputPath/pcap.pcap"),
+            oraclePath = "$oraclePath/pcap.json",
+        )
+    }
+
+    @Test
+    fun scat() {
+        Assumptions.assumeTrue(UtilityForTests.scatIsAvailable())
+        javalinJsonTest(
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "DLF")
+                        putJsonArray("inputIndexes") { add(1) }
+                        put("type", "SDM")
+                        putJsonArray("inputIndexes") { add(0) }
+                        put("type", "HDF")
+                        putJsonArray("inputIndexes") { add(3) }
+                        put("type", "QMDL")
+                        putJsonArray("inputIndexes") { add(2) }
+                    }
+                },
+            files =
+                listOf(
+                    "$inputPath/scat.sdm",
+                    "$inputPath/scat.dlf",
+                    "$inputPath/scat.qmdl",
+                    "$inputPath/scat.hdf"
+                ),
+            oraclePath = "$oraclePath/scat.json",
+        )
+    }
+
+    private fun javalinJsonTest(request: JsonElement, files: List<String>, oraclePath: String) =
+        JavalinTest.test(app) { _, client ->
+            val response =
+                client.request(multiPartRequest(client.origin + endpoint, request, files))
+            Assertions.assertEquals(HttpStatus.OK.code, response.code)
+
+            val string = response.body?.string()
+            val actual = Json.custom().decodeFromString<MultiCapabilities>(string ?: "")
+            val expected =
+                Json.custom().decodeFromString<MultiCapabilities>(File(oraclePath).readText())
+
+            // Size check
+            Assertions.assertEquals(expected.capabilities.size, actual.capabilities.size)
+
+            // Override dynamic properties
+            for (i in expected.capabilities.indices) {
+                val actualCapability = actual.capabilities[i]
+                val expectedCapability = expected.capabilities[i]
+
+                expectedCapability.setMetadata(
+                    "processingTime",
+                    actualCapability.getStringMetadata("processingTime") ?: "",
+                )
+                actualCapability.getStringMetadata("description")?.let {
+                    expectedCapability.setMetadata("description", it)
+                }
+            }
+            expected.id = actual.id
+
+            Assertions.assertEquals(expected, actual)
+        }
+}

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartStoreTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartStoreTest.kt
@@ -1,0 +1,206 @@
+package it.smartphonecombo.uecapabilityparser.server
+
+import io.javalin.http.HttpStatus
+import io.javalin.testtools.JavalinTest
+import it.smartphonecombo.uecapabilityparser.UtilityForTests.multiPartRequest
+import it.smartphonecombo.uecapabilityparser.model.Capabilities
+import it.smartphonecombo.uecapabilityparser.model.MultiCapabilities
+import it.smartphonecombo.uecapabilityparser.model.index.MultiIndexLine
+import it.smartphonecombo.uecapabilityparser.util.Config
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class ServerModeMultiPartStoreTest {
+    private val resourcesPath = "src/test/resources/server"
+    private val endpointParse = arrayOf("/parse/multiPart/", "/parse/multiPart").random()
+    private val tmpStorePath = UUID.randomUUID().toString() + "-tmp"
+    private val storedIds =
+        arrayOf(
+            "9ed9c3fa-9cec-4a44-a6e8-cef8341e8cc3",
+            "08924126-d42f-4425-a4f7-3778ac9a2633",
+            "e2418064-be1d-42ae-9249-7c7d5373b752",
+        )
+    private val storedMultiId = "5a41ca3f-3bd1-469b-930a-97ab7c227807"
+
+    companion object {
+        private var pushedCaps: MultiCapabilities? = null
+    }
+
+    @BeforeEach
+    fun setup() {
+        try {
+            deleteDirectory(tmpStorePath)
+        } catch (_: Exception) {}
+        Config.remove("store")
+    }
+
+    @AfterEach
+    fun teardown() {
+        try {
+            deleteDirectory(tmpStorePath)
+        } catch (_: Exception) {}
+        Config.remove("store")
+    }
+
+    @Test
+    fun storeMultiElement() {
+        Config["store"] = tmpStorePath
+        val inputPrefix = "$resourcesPath/oracleForMultiStore/input/"
+
+        val outputOracles =
+            storedIds.map { storedId -> "$resourcesPath/oracleForMultiStore/output/$storedId.json" }
+        val multiOracle = "$resourcesPath/oracleForMultiStore/multi/$storedMultiId.json"
+
+        val oracleInputs =
+            arrayOf(
+                arrayOf(
+                    "$inputPrefix${storedIds[0]}-0",
+                    "$inputPrefix${storedIds[0]}-1",
+                    "$inputPrefix${storedIds[0]}-2",
+                ),
+                arrayOf("$inputPrefix${storedIds[1]}-0"),
+                arrayOf("$inputPrefix${storedIds[2]}-0"),
+            )
+
+        storeTest(
+            url = endpointParse,
+            request =
+                buildJsonArray {
+                    addJsonObject {
+                        put("type", "H")
+                        putJsonArray("inputIndexes") {
+                            add(0)
+                            add(1)
+                            add(2)
+                        }
+                        putJsonArray("subTypes") {
+                            add("LTE")
+                            add("NR")
+                            add("ENDC")
+                        }
+                        put("description", "This is a multi")
+                    }
+                    addJsonObject {
+                        put("type", "QLTE")
+                        put(
+                            "inputIndexes",
+                            buildJsonArray { add(3) },
+                        )
+                        put("description", "This is a multi test")
+                    }
+                    addJsonObject {
+                        put("type", "QNR")
+                        put(
+                            "inputIndexes",
+                            buildJsonArray { add(4) },
+                        )
+                        put("description", "This is a multi-test")
+                    }
+                },
+            files = oracleInputs.flatten(),
+            oraclePath = "$resourcesPath/oracleForMultiStore/multiParseOutput.json",
+        )
+
+        assumeTrue(pushedCaps != null)
+        val caps = pushedCaps!!
+        for (i in caps.capabilities.indices) {
+            val cap = caps.capabilities[i]
+            val id = cap.id
+            val output = outputOracles[i]
+            val inputs = oracleInputs[i]
+
+            capabilitiesAssertEquals(
+                File(output).readText(),
+                File("$tmpStorePath/output/$id.json").readText(),
+            )
+            for (j in inputs.indices) {
+                Assertions.assertLinesMatch(
+                    File(inputs[j]).readLines(),
+                    File("$tmpStorePath/input/$id-$j").readLines(),
+                )
+            }
+        }
+        multiIndexAssertEquals(
+            File(multiOracle).readText(),
+            File("$tmpStorePath/multi/${caps.id}.json").readText(),
+        )
+    }
+
+    private fun storeTest(
+        url: String,
+        request: JsonElement,
+        files: List<String>,
+        oraclePath: String
+    ) =
+        JavalinTest.test(JavalinApp().app) { _, client ->
+            val response = client.request(multiPartRequest(client.origin + url, request, files))
+            Assertions.assertEquals(HttpStatus.OK.code, response.code)
+            val result = response.body?.string() ?: ""
+            multiCapabilitiesAssertEquals(File(oraclePath).readText(), result)
+        }
+
+    private fun multiCapabilitiesAssertEquals(expected: String, actual: String) {
+        val actualCaps = Json.decodeFromString<MultiCapabilities>(actual)
+        pushedCaps = actualCaps
+        val expectedCaps = Json.decodeFromString<MultiCapabilities>(expected)
+
+        // size check
+        Assertions.assertEquals(expectedCaps.capabilities.size, actualCaps.capabilities.size)
+
+        for (i in expectedCaps.capabilities.indices) {
+            val expectedCap = expectedCaps.capabilities[i]
+            val actualCap = actualCaps.capabilities[i]
+
+            // Override dynamic properties
+            expectedCap.setMetadata(
+                "processingTime",
+                actualCap.getStringMetadata("processingTime") ?: "",
+            )
+
+            Assertions.assertEquals(expectedCap, actualCap)
+        }
+    }
+
+    private fun capabilitiesAssertEquals(expected: String, actual: String) {
+        val actualCap = Json.decodeFromString<Capabilities>(actual)
+        val expectedCap = Json.decodeFromString<Capabilities>(expected)
+
+        // Override dynamic properties
+        expectedCap.setMetadata(
+            "processingTime",
+            actualCap.getStringMetadata("processingTime") ?: "",
+        )
+
+        Assertions.assertEquals(expectedCap, actualCap)
+    }
+
+    private fun multiIndexAssertEquals(expected: String, actual: String) {
+        val actualObj = Json.decodeFromString<MultiIndexLine>(actual)
+        val expectedObj = Json.decodeFromString<MultiIndexLine>(expected)
+
+        Assertions.assertEquals(expectedObj.compressed, actualObj.compressed)
+        Assertions.assertEquals(expectedObj.description, actualObj.description)
+        Assertions.assertEquals(expectedObj.indexLineIds.size, actualObj.indexLineIds.size)
+    }
+
+    private fun deleteDirectory(path: String) {
+        return Files.walk(Path.of(path))
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete)
+    }
+}

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
@@ -26,6 +26,7 @@ internal class ServerModeOthersTest {
             "/parse",
             "/parse/0.1.0",
             "/parse/multi",
+            "/parse/multiPart",
             "/csv",
             "/csv/0.1.0",
             "/openapi",

--- a/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
+++ b/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
@@ -34,7 +34,9 @@ internal object TsTypesGenerator {
                 RequestMultiParse.serializer(),
                 RequestMultiPart.serializer()
             )
-        IO.outputFileOrStdout(warning + typescriptDefinitions, "uecapabilityparser.d.ts")
+        val tsDefFixed =
+            typescriptDefinitions.replace(" = \"\"", "INVALID = \"\"") // fix empty enum
+        IO.outputFileOrStdout(warning + tsDefFixed, "uecapabilityparser.d.ts")
         println("Typescript definitions exported to uecapabilityparser.d.ts")
     }
 }

--- a/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
+++ b/src/tstypes/java/it/smartphonecombo/uecapabilityparser/TsTypesGenerator.kt
@@ -6,6 +6,7 @@ import it.smartphonecombo.uecapabilityparser.model.MultiCapabilities
 import it.smartphonecombo.uecapabilityparser.model.index.LibraryIndex
 import it.smartphonecombo.uecapabilityparser.server.RequestCsv
 import it.smartphonecombo.uecapabilityparser.server.RequestMultiParse
+import it.smartphonecombo.uecapabilityparser.server.RequestMultiPart
 import it.smartphonecombo.uecapabilityparser.server.RequestParse
 import it.smartphonecombo.uecapabilityparser.server.ServerStatus
 import it.smartphonecombo.uecapabilityparser.util.IO
@@ -30,7 +31,8 @@ internal object TsTypesGenerator {
                 ServerStatus.serializer(),
                 RequestCsv.serializer(),
                 RequestParse.serializer(),
-                RequestMultiParse.serializer()
+                RequestMultiParse.serializer(),
+                RequestMultiPart.serializer()
             )
         IO.outputFileOrStdout(warning + typescriptDefinitions, "uecapabilityparser.d.ts")
         println("Typescript definitions exported to uecapabilityparser.d.ts")


### PR DESCRIPTION
`/parse/multiPart` endpoint is a reimplementation of `/parse/multi` using a multipart payload instead of a pure json.
That multipart payload includes:
- one `requests` form parameter, which is the json representation (as a string) of an array of `RequestMultiPart`
- many attached files (`file[]`)

`RequestMultiPart` differs from `RequestMultiParse` in having an array of file indexes (inputIndexes) instead of an array of file contents (inputs). 
These indexes refer to the order in which the files appear in the request (starting with 0). An index cannot be used multiple times.

This endpoint is more efficient because it avoids base64 encoding and can temporary store large files on disk.