### PR TITLE
Refactor JavalinApp

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/CustomJsonMapper.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/CustomJsonMapper.kt
@@ -1,0 +1,30 @@
+package it.smartphonecombo.uecapabilityparser.server
+
+import io.javalin.json.JsonMapper
+import it.smartphonecombo.uecapabilityparser.extension.custom
+import java.io.InputStream
+import java.lang.reflect.Type
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.serializer
+
+@OptIn(ExperimentalSerializationApi::class)
+@Suppress("UNCHECKED_CAST")
+object CustomJsonMapper : JsonMapper {
+    override fun <T : Any> fromJsonString(json: String, targetType: Type): T {
+        val deserializer = serializer(targetType) as KSerializer<T>
+        return Json.custom().decodeFromString(deserializer, json)
+    }
+
+    override fun <T : Any> fromJsonStream(json: InputStream, targetType: Type): T {
+        val deserializer = serializer(targetType) as KSerializer<T>
+        return Json.custom().decodeFromStream(deserializer, json)
+    }
+
+    override fun toJsonString(obj: Any, type: Type): String {
+        val serializer = serializer(obj.javaClass)
+        return Json.custom().encodeToString(serializer, obj)
+    }
+}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
@@ -143,8 +143,6 @@ class JavalinApp {
 
             apiBuilderPost("/csv") { Routes.csv(it) }
 
-            apiBuilderGet("/store/status") { Routes.storeStatus(it, store) }
-
             if (store != null) {
                 apiBuilderGet("/store/list") { Routes.storeList(it, index) }
                 apiBuilderGet("/store/getItem") { Routes.storeGetItem(it, index) }
@@ -158,8 +156,6 @@ class JavalinApp {
                     Routes.storeListFiltered(it, index, store)
                 }
             }
-
-            apiBuilderGet("/version") { Routes.version(it) }
 
             apiBuilderGet("/status") { Routes.status(it, maxRequestSize, endpoints) }
         }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/JavalinApp.kt
@@ -103,35 +103,33 @@ class JavalinApp {
                         ctx.redirect("/swagger/")
                     }
                 }
-                apiBuilderGet("/openapi", "/swagger/openapi.json") { Routes.getOpenApi(it) }
+                addRoute("/openapi", "/swagger/openapi.json") { Routes.getOpenApi(it) }
             }
 
             // Add custom js and custom css
             addStaticGet("custom.js", Config["customJs"], ContentType.TEXT_JS)
             addStaticGet("custom.css", Config["customCss"], ContentType.TEXT_CSS)
 
-            apiBuilderPost("/parse") { Routes.parse(it, store, index, compression) }
-            apiBuilderPost("/parse/multiPart") {
+            addRoute("/parse", post = true) { Routes.parse(it, store, index, compression) }
+            addRoute("/parse/multiPart", post = true) {
                 Routes.parseMultiPart(it, store, index, compression)
             }
 
-            apiBuilderPost("/csv") { Routes.csv(it) }
+            addRoute("/csv", post = true) { Routes.csv(it) }
 
             if (store != null) {
-                apiBuilderGet("/store/list") { Routes.storeList(it, index) }
-                apiBuilderGet("/store/getItem") { Routes.storeGetItem(it, index) }
-                apiBuilderGet("/store/getMultiItem") { Routes.storeGetMultiItem(it, index) }
-                apiBuilderGet("/store/getOutput") { Routes.storeGetOutput(it, index, store) }
-                apiBuilderGet("/store/getMultiOutput") {
-                    Routes.storeGetMultiOutput(it, index, store)
-                }
-                apiBuilderGet("/store/getInput") { Routes.storeGetInput(it, index, store) }
-                apiBuilderPost("/store/list/filtered") {
+                addRoute("/store/list") { Routes.storeList(it, index) }
+                addRoute("/store/getItem") { Routes.storeGetItem(it, index) }
+                addRoute("/store/getMultiItem") { Routes.storeGetMultiItem(it, index) }
+                addRoute("/store/getOutput") { Routes.storeGetOutput(it, index, store) }
+                addRoute("/store/getMultiOutput") { Routes.storeGetMultiOutput(it, index, store) }
+                addRoute("/store/getInput") { Routes.storeGetInput(it, index, store) }
+                addRoute("/store/list/filtered", post = true) {
                     Routes.storeListFiltered(it, index, store)
                 }
             }
 
-            apiBuilderGet("/status") { Routes.status(it, maxRequestSize, endpoints) }
+            addRoute("/status") { Routes.status(it, maxRequestSize, endpoints) }
         }
     }
 
@@ -196,9 +194,13 @@ class JavalinApp {
         }
     }
 
-    private fun apiBuilderGet(vararg paths: String, handler: Handler) {
+    private fun addRoute(vararg paths: String, post: Boolean = false, handler: Handler) {
         for (path in paths) {
-            ApiBuilder.get(path, handler)
+            if (post) {
+                ApiBuilder.post(path, handler)
+            } else {
+                ApiBuilder.get(path, handler)
+            }
             endpoints.add(path)
         }
     }
@@ -210,16 +212,9 @@ class JavalinApp {
             } else {
                 File(filePath).toInputSource()
             }
-        apiBuilderGet(webPath) { ctx ->
+        addRoute(webPath) { ctx ->
             ctx.result(source.inputStream())
             ctx.contentType(contentType)
-        }
-    }
-
-    private fun apiBuilderPost(vararg paths: String, handler: Handler) {
-        for (path in paths) {
-            ApiBuilder.post(path, handler)
-            endpoints.add(path)
         }
     }
 }

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Routes.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Routes.kt
@@ -23,8 +23,6 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.contracts.ExperimentalContracts
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 object Routes {
     private val dataFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
@@ -63,18 +61,6 @@ object Routes {
             "${type}-${date}.csv",
             ContentType.TEXT_CSV
         )
-    }
-
-    fun storeStatus(ctx: Context, store: String?) {
-        val enabled = store != null
-        val json = buildJsonObject { put("enabled", enabled) }
-        ctx.json(json)
-    }
-
-    fun version(ctx: Context) {
-        val version = Config.getOrDefault("project.version", "")
-        val json = buildJsonObject { put("version", version) }
-        ctx.json(json)
     }
 
     fun status(ctx: Context, maxRequestSize: Long, endpoints: List<String>) {

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/Routes.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/Routes.kt
@@ -1,0 +1,161 @@
+package it.smartphonecombo.uecapabilityparser.server
+
+import io.javalin.http.ContentType
+import io.javalin.http.Context
+import it.smartphonecombo.uecapabilityparser.extension.attachFile
+import it.smartphonecombo.uecapabilityparser.extension.bodyAsClassEfficient
+import it.smartphonecombo.uecapabilityparser.extension.custom
+import it.smartphonecombo.uecapabilityparser.extension.mutableListWithCapacity
+import it.smartphonecombo.uecapabilityparser.extension.notFound
+import it.smartphonecombo.uecapabilityparser.extension.toInputSource
+import it.smartphonecombo.uecapabilityparser.io.IOUtils
+import it.smartphonecombo.uecapabilityparser.model.Capabilities
+import it.smartphonecombo.uecapabilityparser.model.LogType
+import it.smartphonecombo.uecapabilityparser.model.MultiCapabilities
+import it.smartphonecombo.uecapabilityparser.model.index.LibraryIndex
+import it.smartphonecombo.uecapabilityparser.query.Query
+import it.smartphonecombo.uecapabilityparser.query.SearchableField
+import it.smartphonecombo.uecapabilityparser.util.Config
+import it.smartphonecombo.uecapabilityparser.util.MultiParsing
+import it.smartphonecombo.uecapabilityparser.util.Parsing
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.contracts.ExperimentalContracts
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+object Routes {
+    private val dataFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
+    private val idRegex = "[a-f0-9-]{36}(?:-[0-9]+)?".toRegex()
+
+    @OptIn(ExperimentalContracts::class)
+    private fun validateId(id: String?) {
+        kotlin.contracts.contract { returns() implies (id != null) }
+        if (id?.matches(idRegex) != true) throw IllegalArgumentException("Wrong id")
+    }
+
+    fun parse(ctx: Context, store: String?, index: LibraryIndex, compression: Boolean) {
+        val request = ctx.bodyAsClassEfficient<RequestParse>()
+        val parsed = Parsing.fromRequest(request)!!
+        ctx.json(parsed.capabilities)
+        if (store != null) parsed.store(index, store, compression)
+    }
+
+    fun parseMultiPart(ctx: Context, store: String?, index: LibraryIndex, compression: Boolean) {
+        val requestsStr = ctx.formParam("requests")!!
+        val requestsJson = Json.custom().decodeFromString<List<RequestMultiPart>>(requestsStr)
+        val files = ctx.uploadedFiles()
+        val parsed = MultiParsing.fromRequest(requestsJson, files)!!
+        ctx.json(parsed.getMultiCapabilities())
+        if (store != null) parsed.store(index, store, compression)
+    }
+
+    fun csv(ctx: Context) {
+        val request = ctx.bodyAsClassEfficient<RequestCsv>()
+        val comboList = request.input
+        val type = request.type
+        val date = dataFormatter.format(ZonedDateTime.now(ZoneOffset.UTC))
+        val newFmt = (request as? RequestCsv.LteCa)?.newCsvFormat ?: false
+        ctx.attachFile(
+            IOUtils.toCsv(comboList, newFmt).toInputSource(),
+            "${type}-${date}.csv",
+            ContentType.TEXT_CSV
+        )
+    }
+
+    fun storeStatus(ctx: Context, store: String?) {
+        val enabled = store != null
+        val json = buildJsonObject { put("enabled", enabled) }
+        ctx.json(json)
+    }
+
+    fun version(ctx: Context) {
+        val version = Config.getOrDefault("project.version", "")
+        val json = buildJsonObject { put("version", version) }
+        ctx.json(json)
+    }
+
+    fun status(ctx: Context, maxRequestSize: Long, endpoints: List<String>) {
+        val version = Config.getOrDefault("project.version", "")
+        val logTypes = LogType.validEntries
+        val status =
+            ServerStatus(
+                version,
+                endpoints,
+                logTypes,
+                maxRequestSize,
+                SearchableField.getAllSearchableFields()
+            )
+        ctx.json(status)
+    }
+
+    fun storeList(ctx: Context, index: LibraryIndex) {
+        ctx.json(index)
+    }
+
+    fun storeGetItem(ctx: Context, index: LibraryIndex) {
+        val id = ctx.queryParam("id") ?: throw IllegalArgumentException("Wrong id")
+        val item = index.find(id) ?: return ctx.notFound()
+        ctx.json(item)
+    }
+
+    fun storeGetMultiItem(ctx: Context, index: LibraryIndex) {
+        val id = ctx.queryParam("id") ?: throw IllegalArgumentException("Wrong id")
+        val item = index.findMulti(id) ?: return ctx.notFound()
+        ctx.json(item)
+    }
+
+    fun storeGetOutput(ctx: Context, index: LibraryIndex, store: String) {
+        val id = ctx.queryParam("id")
+        validateId(id)
+
+        val capabilities = index.getOutput(id, store) ?: return ctx.notFound()
+        ctx.json(capabilities)
+    }
+
+    fun storeGetMultiOutput(ctx: Context, index: LibraryIndex, store: String) {
+        val id = ctx.queryParam("id")
+        validateId(id)
+
+        val multiIndexLine = index.findMulti(id) ?: return ctx.notFound()
+        val indexLineIds = multiIndexLine.indexLineIds
+        val capabilitiesList = mutableListWithCapacity<Capabilities>(indexLineIds.size)
+        for (indexId in indexLineIds) {
+            val capabilities = index.getOutput(indexId, store) ?: continue
+            capabilitiesList.add(capabilities)
+        }
+
+        val multiCapabilities =
+            MultiCapabilities(capabilitiesList, multiIndexLine.description, multiIndexLine.id)
+        ctx.json(multiCapabilities)
+    }
+
+    fun storeGetInput(ctx: Context, index: LibraryIndex, store: String) {
+        val id = ctx.queryParam("id")
+        validateId(id)
+
+        val indexLine = index.findByInput(id) ?: return ctx.notFound()
+        val compressed = indexLine.compressed
+        val filePath = "$store/input/$id"
+
+        val file = IOUtils.getInputSource(filePath, compressed) ?: return ctx.notFound()
+        ctx.attachFile(file, id, ContentType.APPLICATION_OCTET_STREAM)
+    }
+
+    fun storeListFiltered(ctx: Context, index: LibraryIndex, store: String) {
+        val request = ctx.bodyAsClassEfficient<Query>()
+        val result = index.filterByQuery(request, store)
+        ctx.json(result)
+    }
+
+    fun getOpenApi(ctx: Context) {
+        val openapi = {}.javaClass.getResourceAsStream("/swagger/openapi.json")
+        if (openapi != null) {
+            val text = openapi.reader().readText()
+            ctx.contentType(ContentType.JSON)
+            ctx.result(text)
+        }
+    }
+}

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/server/ServerMode.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/server/ServerMode.kt
@@ -7,7 +7,7 @@ object ServerMode {
      * used by the server (useful for input 0)
      */
     fun run(port: Int): Int {
-        val app = JavalinApp().app
+        val app = JavalinApp().newServer()
         app.start(port)
         Runtime.getRuntime().addShutdownHook(Thread { app.stop() })
         return app.port()

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeCompressionTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeCompressionTest.kt
@@ -122,7 +122,7 @@ internal class ServerModeCompressionTest {
         json: Boolean = true,
         gzip: Boolean = false
     ) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             val actualText = response.body?.string() ?: ""
@@ -140,7 +140,7 @@ internal class ServerModeCompressionTest {
         }
 
     private fun storeTest(url: String, request: JsonObject, oraclePath: String) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.post(url, request)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             capabilitiesAssertEquals(

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeCsvTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeCsvTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 internal class ServerModeCsvTest {
     private val path = "src/test/resources/server"
-    private val app = JavalinApp().app
+    private val app = JavalinApp().newServer()
     private val endpoint = arrayOf("/csv/", "/csv").random()
 
     @Test

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeFilterTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeFilterTest.kt
@@ -1,6 +1,5 @@
 package it.smartphonecombo.uecapabilityparser.server
 
-import io.javalin.Javalin
 import io.javalin.http.HttpStatus
 import io.javalin.testtools.JavalinTest
 import it.smartphonecombo.uecapabilityparser.extension.custom
@@ -41,7 +40,6 @@ import org.junit.jupiter.api.TestMethodOrder
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 internal class ServerModeFilterTest {
     private val endpoint = arrayOf("/store/list/filtered/", "/store/list/filtered").random()
-    private var app: Javalin = JavalinApp().app
 
     @Test
     fun emptyResult() {
@@ -303,7 +301,7 @@ internal class ServerModeFilterTest {
     }
 
     private fun javalinTest(request: JsonObject, oraclePath: String) {
-        JavalinTest.test(app) { _, client ->
+        JavalinTest.test(app.newServer()) { _, client ->
             val response = client.post(endpoint, request)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
 
@@ -315,7 +313,7 @@ internal class ServerModeFilterTest {
     }
 
     private fun javalinErrorTest(request: JsonObject, errorCode: Int) {
-        JavalinTest.test(app) { _, client ->
+        JavalinTest.test(app.newServer()) { _, client ->
             val response = client.post(endpoint, request)
             Assertions.assertEquals(errorCode, response.code)
         }
@@ -323,11 +321,14 @@ internal class ServerModeFilterTest {
 
     companion object {
         private val path = "src/test/resources/server/"
+        private lateinit var app: JavalinApp
 
         @JvmStatic
         @BeforeAll
         fun setup() {
             Config["store"] = "$path/inputForQuery/"
+            Config["cache"] = "100"
+            app = JavalinApp()
         }
 
         @JvmStatic

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeFilterTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeFilterTest.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
@@ -327,6 +328,12 @@ internal class ServerModeFilterTest {
         @BeforeAll
         fun setup() {
             Config["store"] = "$path/inputForQuery/"
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardown() {
+            Config.clear()
         }
     }
 }

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 internal class ServerModeMultiPartParseTest {
     private val inputPath = "src/test/resources/cli/input/"
     private val oraclePath = "src/test/resources/server/oracleForMultiParse/"
-    private val app = JavalinApp().app
+    private val app = JavalinApp().newServer()
     private val endpoint = arrayOf("/parse/multiPart", "/parse/multiPart/").random()
 
     @Test

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiStoreTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiStoreTest.kt
@@ -240,7 +240,7 @@ internal class ServerModeMultiStoreTest {
     }
 
     private fun getTest(url: String, oraclePath: String, json: Boolean = true) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             val actualText = response.body?.string() ?: ""
@@ -262,7 +262,7 @@ internal class ServerModeMultiStoreTest {
         files: List<String>,
         oraclePath: String
     ) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response =
                 client.request(
                     UtilityForTests.multiPartRequest(client.origin + url, request, files)
@@ -328,7 +328,7 @@ internal class ServerModeMultiStoreTest {
     }
 
     private fun getTestError(url: String, statusCode: Int) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(statusCode, response.code)
         }

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
@@ -8,10 +8,8 @@ import it.smartphonecombo.uecapabilityparser.query.SearchableField
 import it.smartphonecombo.uecapabilityparser.util.Config
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.put
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -32,7 +30,6 @@ internal class ServerModeOthersTest {
             "/parse",
             "/parse/multiPart",
             "/csv",
-            "/store/status",
             "/store/list",
             "/store/getItem",
             "/store/getMultiItem",
@@ -40,7 +37,6 @@ internal class ServerModeOthersTest {
             "/store/getMultiOutput",
             "/store/getInput",
             "/store/list/filtered",
-            "/version",
             "/status"
         )
 
@@ -80,20 +76,7 @@ internal class ServerModeOthersTest {
     }
 
     @Test
-    fun testVersion() {
-
-        getTest("/version", buildJsonObject { put("version", parserVersion) })
-    }
-
-    @Test
-    fun testStoreEnabled() {
-        Config["store"] = "/store"
-        val endpoint = arrayOf("/store/status/", "/store/status").random()
-        getTest(endpoint, buildJsonObject { put("enabled", true) })
-    }
-
-    @Test
-    fun testStoreOpenApi() {
+    fun testOpenApi() {
         val endpoint = arrayOf("/openapi", "/openapi/").random()
         getTest(endpoint, Json.parseToJsonElement(openapi))
     }
@@ -101,13 +84,6 @@ internal class ServerModeOthersTest {
     @Test
     fun testStoreSwaggerOpenApi() {
         getTest("/swagger/openapi.json", Json.parseToJsonElement(openapi))
-    }
-
-    @Test
-    fun testStatusStoreEnable() {
-        Config["store"] = "/store"
-        val status = ServerStatus(parserVersion, endpoints, logTypes, 256000000, searchableFields)
-        getTest("/status", Json.encodeToJsonElement(status))
     }
 
     @Test

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
@@ -25,13 +25,13 @@ internal class ServerModeOthersTest {
     private val endpoints =
         listOf(
             "/swagger",
+            "/openapi",
+            "/swagger/openapi.json",
             "custom.js",
             "custom.css",
             "/parse",
             "/parse/multiPart",
             "/csv",
-            "/openapi",
-            "/swagger/openapi.json",
             "/store/status",
             "/store/list",
             "/store/getItem",
@@ -41,7 +41,7 @@ internal class ServerModeOthersTest {
             "/store/getInput",
             "/store/list/filtered",
             "/version",
-            "/status",
+            "/status"
         )
 
     private val scatTypes = arrayOf("HDF", "SDM", "DLF", "QMDL")

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeOthersTest.kt
@@ -118,7 +118,7 @@ internal class ServerModeOthersTest {
     }
 
     private fun getTest(url: String, oracle: JsonElement) {
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             val actualText = response.body?.string() ?: ""
@@ -128,7 +128,7 @@ internal class ServerModeOthersTest {
     }
 
     private fun getTestText(url: String, oracle: String) {
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             val actualText = response.body?.string() ?: ""

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeParseTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeParseTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 // This uses the same inputs and oracles of CliJsonOutputTest
 internal class ServerModeParseTest {
     private val path = "src/test/resources/cli"
-    private val app = JavalinApp().app
+    private val app = JavalinApp().newServer()
     private val base64 = Base64.getEncoder()
     private val endpoint = arrayOf("/parse/", "/parse").random()
 

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeStoreTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeStoreTest.kt
@@ -187,7 +187,7 @@ internal class ServerModeStoreTest {
     }
 
     private fun getTest(url: String, oraclePath: String, json: Boolean = true) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             val actualText = response.body?.string() ?: ""
@@ -203,13 +203,13 @@ internal class ServerModeStoreTest {
         }
 
     private fun getTestError(url: String, statusCode: Int) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.get(url)
             Assertions.assertEquals(statusCode, response.code)
         }
 
     private fun storeTest(url: String, request: JsonObject, oraclePath: String) =
-        JavalinTest.test(JavalinApp().app) { _, client ->
+        JavalinTest.test(JavalinApp().newServer()) { _, client ->
             val response = client.post(url, request)
             Assertions.assertEquals(HttpStatus.OK.code, response.code)
             capabilitiesAssertEquals(File(oraclePath).readText(), response.body?.string() ?: "")


### PR DESCRIPTION
- Move routes and jsonMapper in separate classes
- Unify exception handling
- Create new JavalinServer each time with newServer()
- Drop /store/status and /version