### PR TITLE
scat-test: disable description override

### DIFF
--- a/src/test/java/it/smartphonecombo/uecapabilityparser/cli/CliMultiJsonOutputTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/cli/CliMultiJsonOutputTest.kt
@@ -86,7 +86,6 @@ internal class CliMultiJsonOutputTest {
             val capE = expected[i]
 
             capE.setMetadata("processingTime", capA.getStringMetadata("processingTime") ?: "")
-            capA.getStringMetadata("description")?.let { capE.setMetadata("description", it) }
         }
 
         // check files

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/importer/ImportScatTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/importer/ImportScatTest.kt
@@ -50,7 +50,6 @@ internal class ImportScatTest {
             val capE = expected[i]
 
             capE.setMetadata("processingTime", capA.getStringMetadata("processingTime") ?: "")
-            capE.setMetadata("description", capA.getStringMetadata("description") ?: "")
         }
 
         Assertions.assertEquals(expected, actual)

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/server/ServerModeMultiPartParseTest.kt
@@ -416,9 +416,6 @@ internal class ServerModeMultiPartParseTest {
                     "processingTime",
                     actualCapability.getStringMetadata("processingTime") ?: "",
                 )
-                actualCapability.getStringMetadata("description")?.let {
-                    expectedCapability.setMetadata("description", it)
-                }
             }
             expected.id = actual.id
 

--- a/src/test/resources/cli/oracleMultiJson/scat.json
+++ b/src/test/resources/cli/oracleMultiJson/scat.json
@@ -1208,7 +1208,7 @@
         ],
         "metadata": {
             "processingTime": "57ms",
-            "description": "UE Cap from SDM, Timestamps: 1702407031820032"
+            "description": "UE Cap from SDM, Timestamps: 1591378346163000"
         },
         "id": "e8a4fb6a-9d06-46d4-812b-8df6fe3b98f2",
         "parserVersion": "staging",

--- a/src/test/resources/scat/oracle/uecap.sdm.json
+++ b/src/test/resources/scat/oracle/uecap.sdm.json
@@ -1012,7 +1012,7 @@
         ],
         "metadata": {
             "processingTime": "511ms",
-            "description": "UE Cap from SDM, Timestamps: 1702407081457883"
+            "description": "UE Cap from SDM, Timestamps: 1591378346163000"
         },
         "id": "1809b6ea-57ee-45f2-8870-667ac4d01713",
         "parserVersion": "staging",


### PR DESCRIPTION
now scat can read timestamps from sdm too