### PR TITLE
reparse: patch index instead of rebuilding it

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/model/index/LibraryIndex.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/model/index/LibraryIndex.kt
@@ -37,6 +37,15 @@ data class LibraryIndex(
         }
     }
 
+    fun replaceLine(line: IndexLine): Boolean {
+        synchronized(lock) {
+            items.removeIf { it.id == line.id }
+            items.add(line)
+            outputCache.remove(line.id)
+        }
+        return true
+    }
+
     fun addMultiLine(line: MultiIndexLine): Boolean {
         synchronized(lock) {
             return multiItems.add(line)

--- a/src/main/java/it/smartphonecombo/uecapabilityparser/util/LruCache.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/util/LruCache.kt
@@ -21,6 +21,12 @@ class LruCache<K, V>(private val maxCapacity: Int? = null) {
 
     operator fun set(key: K, value: V) = put(key, value)
 
+    fun remove(key: K): V? {
+        synchronized(lock) {
+            return internalMap.remove(key)
+        }
+    }
+
     fun put(key: K, value: V, skipIfFull: Boolean = false): Boolean {
         if (maxCapacity == 0 || skipIfFull && full()) return false
         synchronized(lock) { internalMap[key] = value }


### PR DESCRIPTION
Following one of the router refactorings (cb0c5c74f2dc60162963aa42cb42a67aea51f1b0), the index used in GET/POST requests was immutable, it wasn't replaced by the new index built after reparsing. 
To fix this, patch the index instead of creating a new one.