### PR TITLE
make reparsing tests less prone to failure

### DIFF
--- a/src/test/java/it/smartphonecombo/uecapabilityparser/UtilityForTests.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/UtilityForTests.kt
@@ -57,7 +57,7 @@ object UtilityForTests {
                 } else {
                     val aSize = fileA.readBytes().size
                     val bSize = fileB.readBytes().size
-                    abs(aSize - bSize) < 5 * aSize / 100
+                    abs(aSize - bSize) < maxOf(3 * aSize / 100, 128)
                 }
             }
         return result


### PR DESCRIPTION
Restore max size diff to 3% in dirs_similar, but set its minimum value to 128