### PR TITLE
Add R17/R18 uplink TX switch parsing of UE Capability Information messages (primarily tested with NSG syntax)

### DIFF
--- a/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformation.kt
+++ b/src/main/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformation.kt
@@ -161,6 +161,31 @@ object ImportCapabilityInformation : ImportCapabilities {
                         null,
                         nrBandsMap,
                     )
+                    .typedList<ComboNr>()
+                    .map { combo ->
+                        // R17_2T2T / R17_1T2T require 2 UL layers on every switching band.
+                        // After feature linking the actual MIMO is known, so drop 2T2T/1T2T
+                        // configs from any combo that has a switching band with < 2 UL layers.
+                        if (combo.uplinkTxSwitch.none {
+                                it.type == UplinkTxSwitchType.R17_2T2T ||
+                                    it.type == UplinkTxSwitchType.R17_1T2T
+                            }
+                        ) {
+                            combo
+                        } else {
+                            val all2T =
+                                combo.componentsNr.count { c -> c.ulTxSwitch && c.mimoUL.max() >= 2 } >= 2
+                            if (all2T) combo
+                            else {
+                                val filtered =
+                                    combo.uplinkTxSwitch.filter {
+                                        it.type != UplinkTxSwitchType.R17_2T2T &&
+                                            it.type != UplinkTxSwitchType.R17_1T2T
+                                    }
+                                combo.copy(uplinkTxSwitch = filtered).copy(combo.featureSet)
+                            }
+                        }
+                    }
                     .typedList()
 
             val nrDcCombos = getNrDcBandCombinations(nr, nrCaCombos)
@@ -1608,16 +1633,28 @@ object ImportCapabilityInformation : ImportCapabilities {
         return ueCapFilter
     }
 
-    // R16 ul tx switch NRCA parsing. NRDC, ENDC, ul tx switch R17 and R18 not supported for lack of
-    // samples
+    // R16/R17/R18 ul tx switch NRCA parsing. NRDC and ENDC not supported for lack of samples.
     private fun getUlTxSwitchBandCombinations(nrCapability: UENrCapabilityJson): List<ComboNr> {
         val bandCombinationsPath = "rf-Parameters.supportedBandCombinationList-UplinkTxSwitch-r16"
         val bandCombinationsList = nrCapability.rootJson.getArrayAtPath(bandCombinationsPath)
 
         if (bandCombinationsList == null) return emptyList()
 
+        val v1700List =
+            nrCapability.rootJson.getArrayAtPath(
+                "rf-Parameters.supportedBandCombinationList-UplinkTxSwitch-v1700"
+            )
+        val v1720List =
+            nrCapability.rootJson.getArrayAtPath(
+                "rf-Parameters.supportedBandCombinationList-UplinkTxSwitch-v1720"
+            )
+        val v1800List =
+            nrCapability.rootJson.getArrayAtPath(
+                "rf-Parameters.supportedBandCombinationList-UplinkTxSwitch-v1800"
+            )
+
         val list = mutableListWithCapacity<ComboNr>(bandCombinationsList.size)
-        for (bandCombination in bandCombinationsList) {
+        for ((comboIndex, bandCombination) in bandCombinationsList.withIndex()) {
             val bandCombinationR16 = bandCombination.getObject("bandCombination-r16")
             val bandList = bandCombinationR16?.getArray("bandList") ?: continue
             val nrBands = mutableListWithCapacity<ComponentNr>(bandList.size)
@@ -1635,7 +1672,29 @@ object ImportCapabilityInformation : ImportCapabilities {
 
             val bandPairs = bandCombination.getArray("supportedBandPairListNR-r16") ?: continue
             val optionR16Str = bandCombination.getString("uplinkTxSwitching-OptionSupport-r16")
-            val optionR16 = UplinkTxSwitchOption.valueOf(optionR16Str)
+            // Default to SWITCHED_UL when the field is absent: option 1 (switchedUL) is the
+            // implicit baseline per TS 38.306; some UEs omit the field when only switchedUL
+            // is supported.
+            val optionR16 =
+                if (optionR16Str != null) UplinkTxSwitchOption.valueOf(optionR16Str as String?)
+                else UplinkTxSwitchOption.SWITCHED_UL
+
+            // Collect R17 2T2T info for this combo index.
+            // Two ASN.1 structures are used across UE implementations:
+            // - v1700 with uplinkTxSwitchingBandParametersList-v1700 (PUSCH coherence per band)
+            // - v1700 with supportedBandPairListNR-v1700 (period 2T2T per pair) + v1720 option
+            val v1700Entry = v1700List?.getOrNull(comboIndex)
+            val r17BandParamsList = v1700Entry?.getArray("uplinkTxSwitchingBandParametersList-v1700")
+            val r17BandPairList = v1700Entry?.getArray("supportedBandPairListNR-v1700")
+            val hasR17 = r17BandParamsList != null || r17BandPairList != null
+
+            // v1720 carries uplinkTxSwitching-OptionSupport2T2T-r17 for the newer structure
+            val v1720Entry = v1720List?.getOrNull(comboIndex)
+            val r17OptionStr = v1720Entry?.getString("uplinkTxSwitching-OptionSupport2T2T-r17")
+
+            // Collect R18 band pairs for this combo index, keyed by (ul1, ul2)
+            val v1800Entry = v1800List?.getOrNull(comboIndex)
+            val r18BandPairs = v1800Entry?.getArray("supportedBandPairListNR-r18")
 
             for (pairs in bandPairs) {
                 // -1 because index start from 1
@@ -1658,10 +1717,44 @@ object ImportCapabilityInformation : ImportCapabilities {
                 // sul supports only option 1
                 val ulTxSwitchOption = if (isSUL) UplinkTxSwitchOption.SWITCHED_UL else optionR16
 
-                val type = UplinkTxSwitchType.R16
-                val ulTxSwitchConfig = UplinkTxSwitchConfig(type, ulTxSwitchOption)
+                val ulTxSwitchConfigs = mutableListOf<UplinkTxSwitchConfig>()
 
-                val combo = ComboNr(newBands, featureSetCombination, bcs, listOf(ulTxSwitchConfig))
+                // R16 config (always present when band pair exists)
+                ulTxSwitchConfigs.add(UplinkTxSwitchConfig(UplinkTxSwitchType.R16, ulTxSwitchOption))
+
+                // R17 2T2T: present when either v1700 structure indicates 2T2T support.
+                // Option comes from v1720 uplinkTxSwitching-OptionSupport2T2T-r17 if present,
+                // otherwise falls back to the R16 option.
+                if (hasR17) {
+                    val r17Option =
+                        if (r17OptionStr != null) UplinkTxSwitchOption.valueOf(r17OptionStr as String?)
+                        else ulTxSwitchOption
+                    ulTxSwitchConfigs.add(
+                        UplinkTxSwitchConfig(UplinkTxSwitchType.R17_2T2T, r17Option)
+                    )
+                }
+
+                // R18: per band pair matched by (bandIndexUL1-r18, bandIndexUL2-r18) using 0-based
+                // indices
+                if (r18BandPairs != null) {
+                    for (r18Pair in r18BandPairs) {
+                        val r18ul1 = r18Pair.getInt("bandIndexUL1-r18")?.minus(1)
+                        val r18ul2 = r18Pair.getInt("bandIndexUL2-r18")?.minus(1)
+                        if (r18ul1 != ul1 || r18ul2 != ul2) continue
+
+                        val r18OptionStr =
+                            r18Pair.getString("uplinkTxSwitchingOptionForBandPair-r18")
+                        val r18Option = UplinkTxSwitchOption.valueOf(r18OptionStr as String?)
+                        val periodObj =
+                            r18Pair.getObject("uplinkTxSwitchingPeriodForBandPair-r18")
+                        val has2T = periodObj?.getString("switchingPeriodFor2T-r18") != null
+                        val r18Type =
+                            if (has2T) UplinkTxSwitchType.R18_2T else UplinkTxSwitchType.R18_1T
+                        ulTxSwitchConfigs.add(UplinkTxSwitchConfig(r18Type, r18Option))
+                    }
+                }
+
+                val combo = ComboNr(newBands, featureSetCombination, bcs, ulTxSwitchConfigs)
                 list.add(combo)
             }
         }

--- a/src/test/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformationTest.kt
+++ b/src/test/java/it/smartphonecombo/uecapabilityparser/importer/ImportCapabilityInformationTest.kt
@@ -189,6 +189,11 @@ internal class ImportCapabilityInformationTest :
     }
 
     @Test
+    fun ueCapNrUlTxSwitchR17R18() {
+        parse("ueCapNrUlTxSwitchR17R18.json", "ueCapNrUlTxSwitchR17R18.json")
+    }
+
+    @Test
     fun ueCapNrWithEutraAndMrdc() {
         parse("ueCapNrWithEutraAndMrdc.json", "ueCapNrWithEutraAndMrdc.json")
     }

--- a/src/test/resources/capabilityInformation/input/ueCapNrUlTxSwitchR17R18.json
+++ b/src/test/resources/capabilityInformation/input/ueCapNrUlTxSwitchR17R18.json
@@ -1,0 +1,1714 @@
+{
+    "nr": {
+        "accessStratumRelease": "rel17",
+        "pdcp-Parameters": {
+            "supportedROHC-Profiles": {
+                "profile0x0000": true,
+                "profile0x0001": true,
+                "profile0x0002": true,
+                "profile0x0003": false,
+                "profile0x0004": false,
+                "profile0x0006": false,
+                "profile0x0101": false,
+                "profile0x0102": false,
+                "profile0x0103": false,
+                "profile0x0104": false
+            },
+            "maxNumberROHC-ContextSessions": "cs24",
+            "continueROHC-Context": "supported",
+            "shortSN": "supported"
+        },
+        "rlc-Parameters": {
+            "am-WithShortSN": "supported",
+            "um-WithShortSN": "supported",
+            "um-WithLongSN": "supported"
+        },
+        "mac-Parameters": {
+            "mac-ParametersCommon": {
+                "recommendedBitRate": "supported",
+                "recommendedBitRateQuery": "supported"
+            },
+            "mac-ParametersXDD-Diff": {
+                "logicalChannelSR-DelayTimer": "supported",
+                "longDRX-Cycle": "supported",
+                "shortDRX-Cycle": "supported"
+            }
+        },
+        "phy-Parameters": {
+            "phy-ParametersCommon": {
+                "dynamicHARQ-ACK-Codebook": "supported",
+                "semiStaticHARQ-ACK-Codebook": "supported",
+                "dynamicBetaOffsetInd-HARQ-ACK-CSI": "supported",
+                "ra-Type0-PUSCH": "supported",
+                "dynamicSwitchRA-Type0-1-PUSCH": "supported",
+                "pdsch-MappingTypeA": "supported",
+                "interSlotFreqHopping-PUSCH": "supported",
+                "pusch-RepetitionMultiSlots": "supported",
+                "rateMatchingResrcSetSemi-Static": "supported",
+                "rateMatchingResrcSetDynamic": "supported",
+                "bwp-SwitchingDelay": "type2",
+                "rateMatchingCtrlResrcSetDynamic": "supported",
+                "maxLayersMIMO-Indication": "supported",
+                "codebookVariantsList-r16": [
+                    {
+                        "maxNumberTxPortsPerResource": "p2",
+                        "maxNumberResourcesPerBand": 2,
+                        "totalNumberTxPortsPerBand": 4
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 4,
+                        "totalNumberTxPortsPerBand": 32
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p16",
+                        "maxNumberResourcesPerBand": 2,
+                        "totalNumberTxPortsPerBand": 32
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 1,
+                        "totalNumberTxPortsPerBand": 32
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p2",
+                        "maxNumberResourcesPerBand": 20,
+                        "totalNumberTxPortsPerBand": 40
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 8,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 12,
+                        "totalNumberTxPortsPerBand": 96
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p16",
+                        "maxNumberResourcesPerBand": 6,
+                        "totalNumberTxPortsPerBand": 96
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 3,
+                        "totalNumberTxPortsPerBand": 96
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p16",
+                        "maxNumberResourcesPerBand": 4,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 2,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p2",
+                        "maxNumberResourcesPerBand": 16,
+                        "totalNumberTxPortsPerBand": 32
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p4",
+                        "maxNumberResourcesPerBand": 8,
+                        "totalNumberTxPortsPerBand": 32
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 16,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 16,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 2,
+                        "totalNumberTxPortsPerBand": 40
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 16,
+                        "totalNumberTxPortsPerBand": 128
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p16",
+                        "maxNumberResourcesPerBand": 8,
+                        "totalNumberTxPortsPerBand": 128
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 4,
+                        "totalNumberTxPortsPerBand": 128
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 3,
+                        "totalNumberTxPortsPerBand": 72
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 14,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 17,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 3,
+                        "totalNumberTxPortsPerBand": 80
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 4,
+                        "totalNumberTxPortsPerBand": 80
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 4,
+                        "totalNumberTxPortsPerBand": 96
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 12,
+                        "totalNumberTxPortsPerBand": 64
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 5,
+                        "totalNumberTxPortsPerBand": 160
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 6,
+                        "totalNumberTxPortsPerBand": 164
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p32",
+                        "maxNumberResourcesPerBand": 12,
+                        "totalNumberTxPortsPerBand": 96
+                    },
+                    {
+                        "maxNumberTxPortsPerResource": "p8",
+                        "maxNumberResourcesPerBand": 16,
+                        "totalNumberTxPortsPerBand": 96
+                    }
+                ]
+            },
+            "phy-ParametersXDD-Diff": {
+                "dl-SchedulingOffset-PDSCH-TypeA": "supported"
+            },
+            "phy-ParametersFRX-Diff": {
+                "twoFL-DMRS": "11",
+                "supportedDMRS-TypeDL": "type1And2",
+                "supportedDMRS-TypeUL": "type1And2",
+                "onePortsPTRS": "01",
+                "pucch-F2-WithFH": "supported",
+                "pucch-F3-WithFH": "supported",
+                "pucch-F4-WithFH": "supported",
+                "pdcch-BlindDetectionCA": 6,
+                "tpc-SRS-RNTI": "supported",
+                "absoluteTPC-Command": "supported",
+                "pusch-HalfPi-BPSK": "supported",
+                "pucch-F3-4-HalfPi-BPSK": "supported",
+                "almostContiguousCP-OFDM-UL": "supported",
+                "mux-SR-HARQ-ACK-CSI-PUCCH-OncePerSlot": {
+                    "sameSymbol": "supported"
+                },
+                "dl-SchedulingOffset-PDSCH-TypeA": "supported",
+                "oneFL-DMRS-TwoAdditionalDMRS-UL": "supported",
+                "twoFL-DMRS-TwoAdditionalDMRS-UL": "supported",
+                "maxLayersMIMO-Adaptation-r16": "supported"
+            },
+            "phy-ParametersFR1": {
+                "pdsch-256QAM-FR1": "supported",
+                "pdsch-RE-MappingFR1-PerSymbol": "n10",
+                "pdsch-RE-MappingFR1-PerSlot": "n32"
+            }
+        },
+        "rf-Parameters": {
+            "supportedBandListNR": [
+                {
+                    "bandNR": 41,
+                    "modifiedMPR-Behaviour": "11000000",
+                    "mimo-ParametersPerBand": {
+                        "tci-StatePDSCH": {
+                            "maxNumberConfiguredTCI-StatesPerCC": "n16",
+                            "maxNumberActiveTCI-PerBWP": "n1"
+                        },
+                        "pusch-TransCoherence": "nonCoherent",
+                        "periodicBeamReport": "supported",
+                        "aperiodicBeamReport": "supported",
+                        "maxNumberNonGroupBeamReporting": "n4",
+                        "maxNumberSSB-BFD": 2,
+                        "maxNumberCSI-RS-SSB-CBD": 8,
+                        "beamReportTiming": {
+                            "scs-30kHz": "sym14"
+                        },
+                        "beamManagementSSB-CSI-RS": {
+                            "maxNumberSSB-CSI-RS-ResourceOneTx": "n16",
+                            "maxNumberCSI-RS-Resource": "n64",
+                            "maxNumberCSI-RS-ResourceTwoTx": "n0",
+                            "supportedCSI-RS-Density": "oneAndThree",
+                            "maxNumberAperiodicCSI-RS-Resource": "n32"
+                        },
+                        "codebookParameters": {
+                            "type1": {
+                                "singlePanel": {
+                                    "supportedCSI-RS-ResourceList": [
+                                        {
+                                            "maxNumberTxPortsPerResource": "p8",
+                                            "maxNumberResourcesPerBand": 12,
+                                            "totalNumberTxPortsPerBand": 96
+                                        },
+                                        {
+                                            "maxNumberTxPortsPerResource": "p16",
+                                            "maxNumberResourcesPerBand": 6,
+                                            "totalNumberTxPortsPerBand": 96
+                                        },
+                                        {
+                                            "maxNumberTxPortsPerResource": "p32",
+                                            "maxNumberResourcesPerBand": 3,
+                                            "totalNumberTxPortsPerBand": 96
+                                        }
+                                    ],
+                                    "modes": "mode1",
+                                    "maxNumberCSI-RS-PerResourceSet": 4
+                                }
+                            }
+                        },
+                        "csi-RS-IM-ReceptionForFeedback": {
+                            "maxConfigNumberNZP-CSI-RS-PerCC": 8,
+                            "maxConfigNumberPortsAcrossNZP-CSI-RS-PerCC": 64,
+                            "maxConfigNumberCSI-IM-PerCC": "n8",
+                            "maxNumberSimultaneousNZP-CSI-RS-PerCC": 4,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-PerCC": 32
+                        },
+                        "csi-ReportFramework": {
+                            "maxNumberPeriodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberSemiPersistentCSI-PerBWP-ForCSI-Report": 0,
+                            "maxNumberPeriodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-triggeringStatePerCC": "n63",
+                            "maxNumberSemiPersistentCSI-PerBWP-ForBeamReport": 0,
+                            "simultaneousCSI-ReportsPerCC": 4
+                        },
+                        "csi-RS-ForTracking": {
+                            "maxBurstLength": 2,
+                            "maxSimultaneousResourceSetsPerCC": 1,
+                            "maxConfiguredResourceSetsPerCC": 8,
+                            "maxConfiguredResourceSetsAllCC": 32
+                        },
+                        "codebookParametersPerBand-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    6,
+                                    7,
+                                    8
+                                ]
+                            }
+                        }
+                    },
+                    "multipleTCI": "supported",
+                    "bwp-SameNumerology": "upto2",
+                    "pusch-256QAM": "supported",
+                    "ue-PowerClass": "pc2",
+                    "channelBWs-DL": {
+                        "fr1": {
+                            "scs-15kHz": "0000000000",
+                            "scs-30kHz": "0101011111",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "channelBWs-UL": {
+                        "fr1": {
+                            "scs-15kHz": "0000000000",
+                            "scs-30kHz": "0101011111",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "channelBWs-DL-v1590": {
+                        "fr1": {
+                            "scs-30kHz": "1000000000000000"
+                        }
+                    },
+                    "channelBWs-UL-v1590": {
+                        "fr1": {
+                            "scs-30kHz": "1000000000000000"
+                        }
+                    },
+                    "ue-PowerClass-v1610": "pc1dot5",
+                    "condHandover-r16": "supported",
+                    "condHandoverTwoTriggerEvents-r16": "supported",
+                    "txDiversity-r16": "supported",
+                    "pdsch-1024QAM-FR1-r17": "supported"
+                },
+                {
+                    "bandNR": 28,
+                    "mimo-ParametersPerBand": {
+                        "tci-StatePDSCH": {
+                            "maxNumberConfiguredTCI-StatesPerCC": "n16",
+                            "maxNumberActiveTCI-PerBWP": "n1"
+                        },
+                        "pusch-TransCoherence": "nonCoherent",
+                        "periodicBeamReport": "supported",
+                        "aperiodicBeamReport": "supported",
+                        "maxNumberNonGroupBeamReporting": "n4",
+                        "maxNumberSSB-BFD": 2,
+                        "maxNumberCSI-RS-SSB-CBD": 8,
+                        "beamReportTiming": {
+                            "scs-15kHz": "sym8"
+                        },
+                        "beamManagementSSB-CSI-RS": {
+                            "maxNumberSSB-CSI-RS-ResourceOneTx": "n16",
+                            "maxNumberCSI-RS-Resource": "n64",
+                            "maxNumberCSI-RS-ResourceTwoTx": "n0",
+                            "supportedCSI-RS-Density": "oneAndThree",
+                            "maxNumberAperiodicCSI-RS-Resource": "n32"
+                        },
+                        "codebookParameters": {
+                            "type1": {
+                                "singlePanel": {
+                                    "supportedCSI-RS-ResourceList": [
+                                        {
+                                            "maxNumberTxPortsPerResource": "p8",
+                                            "maxNumberResourcesPerBand": 12,
+                                            "totalNumberTxPortsPerBand": 96
+                                        }
+                                    ],
+                                    "modes": "mode1",
+                                    "maxNumberCSI-RS-PerResourceSet": 4
+                                }
+                            }
+                        },
+                        "csi-RS-IM-ReceptionForFeedback": {
+                            "maxConfigNumberNZP-CSI-RS-PerCC": 8,
+                            "maxConfigNumberPortsAcrossNZP-CSI-RS-PerCC": 64,
+                            "maxConfigNumberCSI-IM-PerCC": "n8",
+                            "maxNumberSimultaneousNZP-CSI-RS-PerCC": 4,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-PerCC": 64
+                        },
+                        "csi-ReportFramework": {
+                            "maxNumberPeriodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberSemiPersistentCSI-PerBWP-ForCSI-Report": 0,
+                            "maxNumberPeriodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-triggeringStatePerCC": "n63",
+                            "maxNumberSemiPersistentCSI-PerBWP-ForBeamReport": 0,
+                            "simultaneousCSI-ReportsPerCC": 4
+                        },
+                        "csi-RS-ForTracking": {
+                            "maxBurstLength": 2,
+                            "maxSimultaneousResourceSetsPerCC": 1,
+                            "maxConfiguredResourceSetsPerCC": 8,
+                            "maxConfiguredResourceSetsAllCC": 32
+                        },
+                        "codebookParametersPerBand-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    6,
+                                    7,
+                                    8
+                                ]
+                            }
+                        }
+                    },
+                    "multipleTCI": "supported",
+                    "pusch-256QAM": "supported",
+                    "ue-PowerClass": "pc3",
+                    "rateMatchingLTE-CRS": "supported",
+                    "channelBWs-DL": {
+                        "fr1": {
+                            "scs-15kHz": "1111110000",
+                            "scs-30kHz": "0000000000",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "channelBWs-UL": {
+                        "fr1": {
+                            "scs-15kHz": "1111110000",
+                            "scs-30kHz": "0000000000",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "condHandover-r16": "supported",
+                    "condHandoverTwoTriggerEvents-r16": "supported"
+                },
+                {
+                    "bandNR": 79,
+                    "mimo-ParametersPerBand": {
+                        "tci-StatePDSCH": {
+                            "maxNumberConfiguredTCI-StatesPerCC": "n16",
+                            "maxNumberActiveTCI-PerBWP": "n1"
+                        },
+                        "pusch-TransCoherence": "nonCoherent",
+                        "periodicBeamReport": "supported",
+                        "aperiodicBeamReport": "supported",
+                        "maxNumberNonGroupBeamReporting": "n4",
+                        "maxNumberSSB-BFD": 2,
+                        "maxNumberCSI-RS-SSB-CBD": 8,
+                        "beamReportTiming": {
+                            "scs-30kHz": "sym14"
+                        },
+                        "beamManagementSSB-CSI-RS": {
+                            "maxNumberSSB-CSI-RS-ResourceOneTx": "n16",
+                            "maxNumberCSI-RS-Resource": "n64",
+                            "maxNumberCSI-RS-ResourceTwoTx": "n0",
+                            "supportedCSI-RS-Density": "oneAndThree",
+                            "maxNumberAperiodicCSI-RS-Resource": "n32"
+                        },
+                        "codebookParameters": {
+                            "type1": {
+                                "singlePanel": {
+                                    "supportedCSI-RS-ResourceList": [
+                                        {
+                                            "maxNumberTxPortsPerResource": "p8",
+                                            "maxNumberResourcesPerBand": 12,
+                                            "totalNumberTxPortsPerBand": 96
+                                        },
+                                        {
+                                            "maxNumberTxPortsPerResource": "p16",
+                                            "maxNumberResourcesPerBand": 6,
+                                            "totalNumberTxPortsPerBand": 96
+                                        },
+                                        {
+                                            "maxNumberTxPortsPerResource": "p32",
+                                            "maxNumberResourcesPerBand": 3,
+                                            "totalNumberTxPortsPerBand": 96
+                                        }
+                                    ],
+                                    "modes": "mode1",
+                                    "maxNumberCSI-RS-PerResourceSet": 4
+                                }
+                            }
+                        },
+                        "csi-RS-IM-ReceptionForFeedback": {
+                            "maxConfigNumberNZP-CSI-RS-PerCC": 8,
+                            "maxConfigNumberPortsAcrossNZP-CSI-RS-PerCC": 64,
+                            "maxConfigNumberCSI-IM-PerCC": "n8",
+                            "maxNumberSimultaneousNZP-CSI-RS-PerCC": 4,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-PerCC": 32
+                        },
+                        "csi-ReportFramework": {
+                            "maxNumberPeriodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberSemiPersistentCSI-PerBWP-ForCSI-Report": 0,
+                            "maxNumberPeriodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-triggeringStatePerCC": "n63",
+                            "maxNumberSemiPersistentCSI-PerBWP-ForBeamReport": 0,
+                            "simultaneousCSI-ReportsPerCC": 4
+                        },
+                        "csi-RS-ForTracking": {
+                            "maxBurstLength": 2,
+                            "maxSimultaneousResourceSetsPerCC": 1,
+                            "maxConfiguredResourceSetsPerCC": 8,
+                            "maxConfiguredResourceSetsAllCC": 32
+                        },
+                        "codebookParametersPerBand-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    6,
+                                    7,
+                                    8
+                                ]
+                            }
+                        }
+                    },
+                    "multipleTCI": "supported",
+                    "bwp-SameNumerology": "upto2",
+                    "pusch-256QAM": "supported",
+                    "ue-PowerClass": "pc2",
+                    "channelBWs-DL": {
+                        "fr1": {
+                            "scs-15kHz": "0000000000",
+                            "scs-30kHz": "0000001111",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "channelBWs-UL": {
+                        "fr1": {
+                            "scs-15kHz": "0000000000",
+                            "scs-30kHz": "0000001111",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "channelBWs-DL-v1590": {
+                        "fr1": {
+                            "scs-30kHz": "1000000000000000"
+                        }
+                    },
+                    "channelBWs-UL-v1590": {
+                        "fr1": {
+                            "scs-30kHz": "1000000000000000"
+                        }
+                    },
+                    "condHandover-r16": "supported",
+                    "condHandoverTwoTriggerEvents-r16": "supported",
+                    "pdsch-1024QAM-FR1-r17": "supported"
+                },
+                {
+                    "bandNR": 83,
+                    "mimo-ParametersPerBand": {
+                        "pusch-TransCoherence": "nonCoherent",
+                        "periodicBeamReport": "supported",
+                        "aperiodicBeamReport": "supported",
+                        "maxNumberNonGroupBeamReporting": "n4",
+                        "maxNumberSSB-BFD": 2,
+                        "maxNumberCSI-RS-SSB-CBD": 8,
+                        "beamReportTiming": {
+                            "scs-15kHz": "sym8"
+                        },
+                        "beamManagementSSB-CSI-RS": {
+                            "maxNumberSSB-CSI-RS-ResourceOneTx": "n16",
+                            "maxNumberCSI-RS-Resource": "n64",
+                            "maxNumberCSI-RS-ResourceTwoTx": "n0",
+                            "supportedCSI-RS-Density": "oneAndThree",
+                            "maxNumberAperiodicCSI-RS-Resource": "n32"
+                        },
+                        "codebookParameters": {
+                            "type1": {
+                                "singlePanel": {
+                                    "supportedCSI-RS-ResourceList": [
+                                        {
+                                            "maxNumberTxPortsPerResource": "p8",
+                                            "maxNumberResourcesPerBand": 12,
+                                            "totalNumberTxPortsPerBand": 96
+                                        }
+                                    ],
+                                    "modes": "mode1",
+                                    "maxNumberCSI-RS-PerResourceSet": 4
+                                }
+                            }
+                        },
+                        "csi-RS-IM-ReceptionForFeedback": {
+                            "maxConfigNumberNZP-CSI-RS-PerCC": 8,
+                            "maxConfigNumberPortsAcrossNZP-CSI-RS-PerCC": 64,
+                            "maxConfigNumberCSI-IM-PerCC": "n8",
+                            "maxNumberSimultaneousNZP-CSI-RS-PerCC": 4,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-PerCC": 64
+                        },
+                        "csi-ReportFramework": {
+                            "maxNumberPeriodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForCSI-Report": 2,
+                            "maxNumberSemiPersistentCSI-PerBWP-ForCSI-Report": 0,
+                            "maxNumberPeriodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-PerBWP-ForBeamReport": 2,
+                            "maxNumberAperiodicCSI-triggeringStatePerCC": "n63",
+                            "maxNumberSemiPersistentCSI-PerBWP-ForBeamReport": 0,
+                            "simultaneousCSI-ReportsPerCC": 4
+                        },
+                        "csi-RS-ForTracking": {
+                            "maxBurstLength": 2,
+                            "maxSimultaneousResourceSetsPerCC": 1,
+                            "maxConfiguredResourceSetsPerCC": 8,
+                            "maxConfiguredResourceSetsAllCC": 32
+                        },
+                        "codebookParametersPerBand-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    6,
+                                    7,
+                                    8
+                                ]
+                            }
+                        }
+                    },
+                    "multipleTCI": "supported",
+                    "pusch-256QAM": "supported",
+                    "ue-PowerClass": "pc3",
+                    "channelBWs-UL": {
+                        "fr1": {
+                            "scs-15kHz": "1111010000",
+                            "scs-30kHz": "0000000000",
+                            "scs-60kHz": "0000000000"
+                        }
+                    },
+                    "condHandover-r16": "supported",
+                    "condHandoverTwoTriggerEvents-r16": "supported"
+                }
+            ],
+            "supportedBandCombinationList": [
+                {
+                    "bandList": [
+                        {
+                            "nr": {
+                                "bandNR": 28,
+                                "ca-BandwidthClassDL-NR": "a",
+                                "ca-BandwidthClassUL-NR": "a"
+                            }
+                        },
+                        {
+                            "nr": {
+                                "bandNR": 41,
+                                "ca-BandwidthClassDL-NR": "a",
+                                "ca-BandwidthClassUL-NR": "a"
+                            }
+                        }
+                    ],
+                    "featureSetCombination": 2,
+                    "ca-ParametersNR": {
+                        "parallelTxSRS-PUCCH-PUSCH": "supported",
+                        "parallelTxPRACH-SRS-PUCCH-PUSCH": "supported",
+                        "simultaneousRxTxInterBandCA": "supported",
+                        "diffNumerologyWithinPUCCH-GroupSmallerSCS": "supported",
+                        "supportedNumberTAG": "n2"
+                    },
+                    "supportedBandwidthCombinationSet": "11001",
+                    "powerClass-v1530": "pc2"
+                },
+                {
+                    "bandList": [
+                        {
+                            "nr": {
+                                "bandNR": 28,
+                                "ca-BandwidthClassDL-NR": "a"
+                            }
+                        },
+                        {
+                            "nr": {
+                                "bandNR": 41,
+                                "ca-BandwidthClassDL-NR": "c",
+                                "ca-BandwidthClassUL-NR": "a"
+                            }
+                        }
+                    ],
+                    "featureSetCombination": 3,
+                    "ca-ParametersNR": {
+                        "simultaneousRxTxInterBandCA": "supported",
+                        "supportedNumberTAG": "n2"
+                    },
+                    "supportedBandwidthCombinationSet": "10001",
+                    "powerClass-v1530": "pc2"
+                },
+                {
+                    "bandList": [
+                        {
+                            "nr": {
+                                "bandNR": 28,
+                                "ca-BandwidthClassDL-NR": "a",
+                                "ca-BandwidthClassUL-NR": "a"
+                            }
+                        },
+                        {
+                            "nr": {
+                                "bandNR": 41,
+                                "ca-BandwidthClassDL-NR": "c"
+                            }
+                        }
+                    ],
+                    "featureSetCombination": 4,
+                    "ca-ParametersNR": {
+                        "simultaneousRxTxInterBandCA": "supported",
+                        "diffNumerologyWithinPUCCH-GroupSmallerSCS": "supported",
+                        "supportedNumberTAG": "n2"
+                    },
+                    "supportedBandwidthCombinationSet": "10001"
+                }
+            ],
+            "appliedFreqBandListFilter": [
+                {
+                    "bandInformationNR": {
+                        "bandNR": 41,
+                        "maxCarriersRequestedDL": 3,
+                        "maxCarriersRequestedUL": 3
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 28,
+                        "maxCarriersRequestedDL": 2,
+                        "maxCarriersRequestedUL": 2
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 5,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 8,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 1,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 78,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 77,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 80,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 81,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 82,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 83,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 84,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                },
+                {
+                    "bandInformationNR": {
+                        "bandNR": 86,
+                        "maxCarriersRequestedDL": 1,
+                        "maxCarriersRequestedUL": 1
+                    }
+                }
+            ],
+            "supportedBandCombinationList-v1540": [
+                {
+                    "bandList-v1540": [
+                        {
+                            "srs-CarrierSwitch": {
+                                "nr": {
+                                    "srs-SwitchingTimesListNR": [
+                                        {},
+                                        {
+                                            "switchingTimeDL": "n0us",
+                                            "switchingTimeUL": "n30us"
+                                        }
+                                    ]
+                                }
+                            },
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "notSupported"
+                            }
+                        },
+                        {
+                            "srs-CarrierSwitch": {
+                                "nr": {
+                                    "srs-SwitchingTimesListNR": [
+                                        {}
+                                    ]
+                                }
+                            },
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "t1r4"
+                            }
+                        }
+                    ],
+                    "ca-ParametersNR-v1540": {
+                        "csi-RS-IM-ReceptionForFeedbackPerBandComb": {
+                            "maxNumberSimultaneousNZP-CSI-RS-ActBWP-AllCC": 16,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-ActBWP-AllCC": 164
+                        },
+                        "simultaneousCSI-ReportsAllCC": 16
+                    }
+                },
+                {
+                    "bandList-v1540": [
+                        {
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "notSupported"
+                            }
+                        },
+                        {
+                            "srs-CarrierSwitch": {
+                                "nr": {
+                                    "srs-SwitchingTimesListNR": [
+                                        {
+                                            "switchingTimeDL": "n0us",
+                                            "switchingTimeUL": "n100us"
+                                        }
+                                    ]
+                                }
+                            },
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "t2r4"
+                            }
+                        }
+                    ],
+                    "ca-ParametersNR-v1540": {
+                        "csi-RS-IM-ReceptionForFeedbackPerBandComb": {
+                            "maxNumberSimultaneousNZP-CSI-RS-ActBWP-AllCC": 16,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-ActBWP-AllCC": 164
+                        },
+                        "simultaneousCSI-ReportsAllCC": 16
+                    }
+                },
+                {
+                    "bandList-v1540": [
+                        {
+                            "srs-CarrierSwitch": {
+                                "nr": {
+                                    "srs-SwitchingTimesListNR": [
+                                        {},
+                                        {
+                                            "switchingTimeDL": "n0us",
+                                            "switchingTimeUL": "n100us"
+                                        }
+                                    ]
+                                }
+                            },
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "notSupported"
+                            }
+                        },
+                        {
+                            "srs-CarrierSwitch": {
+                                "nr": {
+                                    "srs-SwitchingTimesListNR": [
+                                        {}
+                                    ]
+                                }
+                            },
+                            "srs-TxSwitch": {
+                                "supportedSRS-TxPortSwitch": "t1r4"
+                            }
+                        }
+                    ],
+                    "ca-ParametersNR-v1540": {
+                        "csi-RS-IM-ReceptionForFeedbackPerBandComb": {
+                            "maxNumberSimultaneousNZP-CSI-RS-ActBWP-AllCC": 16,
+                            "totalNumberPortsSimultaneousNZP-CSI-RS-ActBWP-AllCC": 164
+                        },
+                        "simultaneousCSI-ReportsAllCC": 16
+                    }
+                }
+            ],
+            "srs-SwitchingTimeRequested": "true",
+            "supportedBandCombinationList-v1560": [
+                {
+                    "ca-ParametersNR-v1560": {
+                        "diffNumerologyWithinPUCCH-GroupLargerSCS": "supported"
+                    }
+                },
+                {
+                    "ca-ParametersNR-v1560": {
+                        "diffNumerologyWithinPUCCH-GroupLargerSCS": "supported"
+                    }
+                },
+                {
+                    "ca-ParametersNR-v1560": {}
+                }
+            ],
+            "supportedBandCombinationList-v1610": [
+                {
+                    "ca-ParametersNR-v1610": {
+                        "codebookParametersPerBC-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    6,
+                                    7,
+                                    8
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "ca-ParametersNR-v1610": {
+                        "codebookParametersPerBC-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    16,
+                                    17,
+                                    18
+                                ]
+                            }
+                        }
+                    },
+                    "powerClass-v1610": "pc1dot5"
+                },
+                {
+                    "ca-ParametersNR-v1610": {
+                        "codebookParametersPerBC-r16": {
+                            "supportedCSI-RS-ResourceListAlt-r16": {
+                                "type1-SinglePanel-r16": [
+                                    16,
+                                    17,
+                                    18
+                                ]
+                            }
+                        }
+                    }
+                }
+            ],
+            "supportedBandCombinationList-UplinkTxSwitch-r16": [
+                {
+                    "bandCombination-r16": {
+                        "bandList": [
+                            {
+                                "nr": {
+                                    "bandNR": 28,
+                                    "ca-BandwidthClassDL-NR": "a",
+                                    "ca-BandwidthClassUL-NR": "a"
+                                }
+                            },
+                            {
+                                "nr": {
+                                    "bandNR": 41,
+                                    "ca-BandwidthClassDL-NR": "a",
+                                    "ca-BandwidthClassUL-NR": "a"
+                                }
+                            }
+                        ],
+                        "featureSetCombination": 1,
+                        "ca-ParametersNR": {
+                            "parallelTxSRS-PUCCH-PUSCH": "supported",
+                            "parallelTxPRACH-SRS-PUCCH-PUSCH": "supported",
+                            "simultaneousRxTxInterBandCA": "supported",
+                            "diffNumerologyWithinPUCCH-GroupSmallerSCS": "supported"
+                        },
+                        "supportedBandwidthCombinationSet": "11001",
+                        "powerClass-v1530": "pc2"
+                    },
+                    "bandCombination-v1540": {
+                        "bandList-v1540": [
+                            {
+                                "srs-TxSwitch": {
+                                    "supportedSRS-TxPortSwitch": "notSupported"
+                                }
+                            },
+                            {
+                                "srs-TxSwitch": {
+                                    "supportedSRS-TxPortSwitch": "t2r4"
+                                }
+                            }
+                        ],
+                        "ca-ParametersNR-v1540": {
+                            "csi-RS-IM-ReceptionForFeedbackPerBandComb": {
+                                "maxNumberSimultaneousNZP-CSI-RS-ActBWP-AllCC": 16,
+                                "totalNumberPortsSimultaneousNZP-CSI-RS-ActBWP-AllCC": 164
+                            },
+                            "simultaneousCSI-ReportsAllCC": 16
+                        }
+                    },
+                    "bandCombination-v1560": {
+                        "ca-ParametersNR-v1560": {
+                            "diffNumerologyWithinPUCCH-GroupLargerSCS": "supported"
+                        }
+                    },
+                    "bandCombination-v1610": {
+                        "ca-ParametersNR-v1610": {
+                            "codebookParametersPerBC-r16": {
+                                "supportedCSI-RS-ResourceListAlt-r16": {
+                                    "type1-SinglePanel-r16": [
+                                        6,
+                                        7,
+                                        8
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "supportedBandPairListNR-r16": [
+                        {
+                            "bandIndexUL1-r16": 1,
+                            "bandIndexUL2-r16": 2,
+                            "uplinkTxSwitchingPeriod-r16": "n140us"
+                        }
+                    ],
+                    "uplinkTxSwitching-OptionSupport-r16": "switchedUL"
+                },
+                {
+                    "bandCombination-r16": {
+                        "bandList": [
+                            {
+                                "nr": {
+                                    "bandNR": 41,
+                                    "ca-BandwidthClassDL-NR": "a",
+                                    "ca-BandwidthClassUL-NR": "a"
+                                }
+                            },
+                            {
+                                "nr": {
+                                    "bandNR": 83,
+                                    "ca-BandwidthClassUL-NR": "a"
+                                }
+                            }
+                        ],
+                        "featureSetCombination": 0,
+                        "ca-ParametersNR": {
+                            "simultaneousRxTxSUL": "supported"
+                        },
+                        "supportedBandwidthCombinationSet": "10001",
+                        "powerClass-v1530": "pc2"
+                    },
+                    "bandCombination-v1540": {
+                        "bandList-v1540": [
+                            {
+                                "srs-TxSwitch": {
+                                    "supportedSRS-TxPortSwitch": "t2r4"
+                                }
+                            },
+                            {
+                                "srs-TxSwitch": {
+                                    "supportedSRS-TxPortSwitch": "notSupported"
+                                }
+                            }
+                        ],
+                        "ca-ParametersNR-v1540": {
+                            "csi-RS-IM-ReceptionForFeedbackPerBandComb": {
+                                "maxNumberSimultaneousNZP-CSI-RS-ActBWP-AllCC": 16,
+                                "totalNumberPortsSimultaneousNZP-CSI-RS-ActBWP-AllCC": 164
+                            },
+                            "simultaneousCSI-ReportsAllCC": 16
+                        }
+                    },
+                    "bandCombination-v1560": {
+                        "ca-ParametersNR-v1560": {}
+                    },
+                    "bandCombination-v1610": {
+                        "ca-ParametersNR-v1610": {
+                            "codebookParametersPerBC-r16": {
+                                "supportedCSI-RS-ResourceListAlt-r16": {
+                                    "type1-SinglePanel-r16": [
+                                        6,
+                                        7,
+                                        8
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "supportedBandPairListNR-r16": [
+                        {
+                            "bandIndexUL1-r16": 1,
+                            "bandIndexUL2-r16": 2,
+                            "uplinkTxSwitchingPeriod-r16": "n140us"
+                        }
+                    ]
+                }
+            ],
+            "supportedBandCombinationList-UplinkTxSwitch-v1700": [
+                {},
+                {
+                    "uplinkTxSwitchingBandParametersList-v1700": [
+                        {
+                            "bandIndex-r17": 1,
+                            "uplinkTxSwitching2T2T-PUSCH-TransCoherence-r17": "nonCoherent"
+                        },
+                        {
+                            "bandIndex-r17": 2,
+                            "uplinkTxSwitching2T2T-PUSCH-TransCoherence-r17": "nonCoherent"
+                        }
+                    ]
+                }
+            ],
+            "supportedBandCombinationList-UplinkTxSwitch-v1800": [
+                {
+                    "supportedBandPairListNR-r18": [
+                        {
+                            "bandIndexUL1-r18": 1,
+                            "bandIndexUL2-r18": 2,
+                            "uplinkTxSwitchingOptionForBandPair-r18": "switchedUL",
+                            "uplinkTxSwitchingPeriodForBandPair-r18": {
+                                "switchingPeriodFor1T-r18": "n140us"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "supportedBandPairListNR-r18": [
+                        {
+                            "bandIndexUL1-r18": 1,
+                            "bandIndexUL2-r18": 2,
+                            "uplinkTxSwitchingOptionForBandPair-r18": "switchedUL",
+                            "uplinkTxSwitchingPeriodForBandPair-r18": {
+                                "switchingPeriodFor2T-r18": "n140us",
+                                "switchingPeriodFor1T-r18": "n140us"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "measAndMobParameters": {
+            "measAndMobParametersCommon": {
+                "ssb-RLM": "supported",
+                "eventB-MeasAndReport": "supported",
+                "handoverFDD-TDD": "supported",
+                "eutra-CGI-Reporting": "supported",
+                "nr-CGI-Reporting": "supported",
+                "periodicEUTRA-MeasAndReport": "supported",
+                "nr-CGI-Reporting-ENDC": "supported",
+                "reportAddNeighMeasForPeriodic-r16": "supported",
+                "condHandoverParametersCommon-r16": {
+                    "condHandoverFDD-TDD-r16": "supported"
+                },
+                "supportedGapPattern-NRonly-r16": "1101000001"
+            },
+            "measAndMobParametersXDD-Diff": {
+                "intraAndInterF-MeasAndReport": "supported",
+                "eventA-MeasAndReport": "supported",
+                "handoverInterF": "supported",
+                "handoverLTE-EPC": "supported"
+            },
+            "measAndMobParametersFRX-Diff": {
+                "ss-SINR-Meas": "supported",
+                "handoverInterF": "supported",
+                "handoverLTE-EPC": "supported",
+                "simultaneousRxDataSSB-DiffNumerology": "supported"
+            }
+        },
+        "featureSets": {
+            "featureSetsDownlink": [
+                {
+                    "featureSetListPerDownlinkCC": [
+                        1
+                    ],
+                    "ue-SpecificUL-DL-Assignment": "supported"
+                },
+                {
+                    "featureSetListPerDownlinkCC": [
+                        2
+                    ],
+                    "ue-SpecificUL-DL-Assignment": "supported"
+                },
+                {
+                    "featureSetListPerDownlinkCC": [
+                        1,
+                        3
+                    ],
+                    "ue-SpecificUL-DL-Assignment": "supported"
+                },
+                {
+                    "featureSetListPerDownlinkCC": [
+                        1,
+                        3
+                    ],
+                    "ue-SpecificUL-DL-Assignment": "supported"
+                }
+            ],
+            "featureSetsDownlinkPerCC": [
+                {
+                    "supportedSubcarrierSpacingDL": "kHz30",
+                    "supportedBandwidthDL": {
+                        "fr1": "mhz100"
+                    },
+                    "channelBW-90mhz": "supported",
+                    "maxNumberMIMO-LayersPDSCH": "fourLayers"
+                },
+                {
+                    "supportedSubcarrierSpacingDL": "kHz15",
+                    "supportedBandwidthDL": {
+                        "fr1": "mhz30"
+                    },
+                    "maxNumberMIMO-LayersPDSCH": "fourLayers",
+                    "supportedModulationOrderDL": "qam256"
+                },
+                {
+                    "supportedSubcarrierSpacingDL": "kHz30",
+                    "supportedBandwidthDL": {
+                        "fr1": "mhz80"
+                    },
+                    "channelBW-90mhz": "supported",
+                    "maxNumberMIMO-LayersPDSCH": "fourLayers"
+                }
+            ],
+            "featureSetsUplink": [
+                {
+                    "featureSetListPerUplinkCC": [
+                        1
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n8",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 4,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n2"
+                    },
+                    "dynamicSwitchSUL": "supported"
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        2
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n1",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n1"
+                    },
+                    "dynamicSwitchSUL": "supported"
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        2
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n1",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n1"
+                    }
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        1
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n8",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 4,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n2"
+                    }
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        3
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n8",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 4,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n1"
+                    }
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        1
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n8",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 4,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n2"
+                    }
+                },
+                {
+                    "featureSetListPerUplinkCC": [
+                        2
+                    ],
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n1",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n1"
+                    }
+                }
+            ],
+            "featureSetsUplinkPerCC": [
+                {
+                    "supportedSubcarrierSpacingUL": "kHz30",
+                    "supportedBandwidthUL": {
+                        "fr1": "mhz100"
+                    },
+                    "channelBW-90mhz": "supported",
+                    "mimo-CB-PUSCH": {
+                        "maxNumberMIMO-LayersCB-PUSCH": "twoLayers",
+                        "maxNumberSRS-ResourcePerSet": 1
+                    },
+                    "supportedModulationOrderUL": "qam256"
+                },
+                {
+                    "supportedSubcarrierSpacingUL": "kHz15",
+                    "supportedBandwidthUL": {
+                        "fr1": "mhz30"
+                    },
+                    "mimo-CB-PUSCH": {
+                        "maxNumberMIMO-LayersCB-PUSCH": "oneLayer",
+                        "maxNumberSRS-ResourcePerSet": 1
+                    },
+                    "supportedModulationOrderUL": "qam256"
+                },
+                {
+                    "supportedSubcarrierSpacingUL": "kHz30",
+                    "supportedBandwidthUL": {
+                        "fr1": "mhz100"
+                    },
+                    "channelBW-90mhz": "supported",
+                    "mimo-CB-PUSCH": {
+                        "maxNumberMIMO-LayersCB-PUSCH": "oneLayer",
+                        "maxNumberSRS-ResourcePerSet": 1
+                    },
+                    "supportedModulationOrderUL": "qam256"
+                }
+            ],
+            "featureSetsDownlink-v1540": [
+                {
+                    "oneFL-DMRS-TwoAdditionalDMRS-DL": "supported",
+                    "twoFL-DMRS-TwoAdditionalDMRS-DL": "supported"
+                },
+                {
+                    "oneFL-DMRS-TwoAdditionalDMRS-DL": "supported",
+                    "additionalDMRS-DL-Alt": "supported",
+                    "twoFL-DMRS-TwoAdditionalDMRS-DL": "supported"
+                },
+                {
+                    "oneFL-DMRS-TwoAdditionalDMRS-DL": "supported",
+                    "twoFL-DMRS-TwoAdditionalDMRS-DL": "supported"
+                },
+                {
+                    "oneFL-DMRS-TwoAdditionalDMRS-DL": "supported",
+                    "twoFL-DMRS-TwoAdditionalDMRS-DL": "supported"
+                }
+            ],
+            "featureSetsUplink-v1540": [
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                },
+                {
+                    "pa-PhaseDiscontinuityImpacts": "supported"
+                }
+            ],
+            "featureSetsDownlink-v15a0": [
+                {},
+                {},
+                {},
+                {
+                    "supportedSRS-Resources": {
+                        "maxNumberAperiodicSRS-PerBWP": "n1",
+                        "maxNumberAperiodicSRS-PerBWP-PerSlot": 1,
+                        "maxNumberPeriodicSRS-PerBWP": "n8",
+                        "maxNumberPeriodicSRS-PerBWP-PerSlot": 4,
+                        "maxNumberSemiPersistentSRS-PerBWP": "n1",
+                        "maxNumberSemiPersistentSRS-PerBWP-PerSlot": 1,
+                        "maxNumberSRS-Ports-PerResource": "n1"
+                    }
+                }
+            ],
+            "featureSetsUplink-v1610": [
+                {
+                    "ul-FullPwrMode-r16": "supported"
+                },
+                {},
+                {},
+                {
+                    "ul-FullPwrMode-r16": "supported"
+                },
+                {},
+                {
+                    "ul-FullPwrMode1-r16": "supported"
+                },
+                {}
+            ],
+            "featureSetsUplink-v1630": [
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                },
+                {
+                    "offsetSRS-CB-PUSCH-Ant-Switch-fr1-r16": "supported"
+                }
+            ],
+            "featureSetsDownlinkPerCC-v1700": [
+                {
+                    "supportedBandwidthDL-v1710": {
+                        "fr1-r17": "mhz100"
+                    }
+                },
+                {
+                    "supportedBandwidthDL-v1710": {
+                        "fr1-r17": "mhz30"
+                    }
+                },
+                {
+                    "supportedBandwidthDL-v1710": {
+                        "fr1-r17": "mhz90"
+                    }
+                }
+            ],
+            "featureSetsUplink-v1710": [
+                {
+                    "ue-PowerClassPerBandPerBC-r17": "pc2"
+                },
+                {
+                    "ue-PowerClassPerBandPerBC-r17": "pc3"
+                },
+                {
+                    "ue-PowerClassPerBandPerBC-r17": "pc3"
+                },
+                {
+                    "ue-PowerClassPerBandPerBC-r17": "pc2"
+                },
+                {
+                    "ue-PowerClassPerBandPerBC-r17": "pc2"
+                },
+                {},
+                {}
+            ],
+            "featureSetsUplinkPerCC-v1700": [
+                {
+                    "supportedBandwidthUL-v1710": {
+                        "fr1-r17": "mhz100"
+                    }
+                },
+                {
+                    "supportedBandwidthUL-v1710": {
+                        "fr1-r17": "mhz30"
+                    }
+                },
+                {
+                    "supportedBandwidthUL-v1710": {
+                        "fr1-r17": "mhz100"
+                    }
+                }
+            ]
+        },
+        "featureSetCombinations": [
+            [
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 1,
+                            "uplinkSetNR": 1
+                        }
+                    }
+                ],
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 0,
+                            "uplinkSetNR": 2
+                        }
+                    }
+                ]
+            ],
+            [
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 2,
+                            "uplinkSetNR": 3
+                        }
+                    }
+                ],
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 1,
+                            "uplinkSetNR": 4
+                        }
+                    }
+                ]
+            ],
+            [
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 2,
+                            "uplinkSetNR": 3
+                        }
+                    }
+                ],
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 1,
+                            "uplinkSetNR": 5
+                        }
+                    }
+                ]
+            ],
+            [
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 2,
+                            "uplinkSetNR": 0
+                        }
+                    }
+                ],
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 3,
+                            "uplinkSetNR": 6
+                        }
+                    }
+                ]
+            ],
+            [
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 2,
+                            "uplinkSetNR": 7
+                        }
+                    }
+                ],
+                [
+                    {
+                        "nr": {
+                            "downlinkSetNR": 4,
+                            "uplinkSetNR": 0
+                        }
+                    }
+                ]
+            ]
+        ],
+        "nonCriticalExtension": {
+            "interRAT-Parameters": {
+                "eutra": {
+                    "supportedBandListEUTRA": [
+                        3,
+                        8,
+                        34,
+                        38,
+                        39,
+                        40,
+                        41
+                    ],
+                    "eutra-ParametersCommon": {
+                        "mfbi-EUTRA": "supported"
+                    }
+                }
+            },
+            "nonCriticalExtension": {
+                "overheatingInd": "supported",
+                "ims-Parameters": {
+                    "ims-ParametersCommon": {
+                        "voiceFallbackIndicationEPS-r16": "supported"
+                    },
+                    "ims-ParametersFRX-Diff": {
+                        "voiceOverNR": "supported"
+                    }
+                },
+                "nonCriticalExtension": {
+                    "nonCriticalExtension": {
+                        "receivedFilters": {
+                            "capabilityRequestFilterCommon": {
+                                "uplinkTxSwitchRequest-r16": "true"
+                            }
+                        },
+                        "nonCriticalExtension": {
+                            "nonCriticalExtension": {
+                                "powSav-Parameters-r16": {
+                                    "powSav-ParametersCommon-r16": {
+                                        "maxCC-Preference-r16": "supported",
+                                        "releasePreference-r16": "supported"
+                                    },
+                                    "powSav-ParametersFRX-Diff-r16": {
+                                        "maxMIMO-LayerPreference-r16": "supported"
+                                    }
+                                },
+                                "highSpeedParameters-r16": {
+                                    "measurementEnhancement-r16": "supported",
+                                    "demodulationEnhancement-r16": "supported"
+                                },
+                                "mac-Parameters-v1610": {
+                                    "mac-ParametersFRX-Diff-r16": {
+                                        "drx-Adaptation-r16": {
+                                            "non-SharedSpectrumChAccess-r16": {
+                                                "scs-15kHz-r16": "sl3",
+                                                "scs-30kHz-r16": "sl6"
+                                            }
+                                        }
+                                    }
+                                },
+                                "ue-BasedPerfMeas-Parameters-r16": {
+                                    "loggedMeasurements-r16": "supported",
+                                    "gnss-Location-r16": "supported"
+                                },
+                                "son-Parameters-r16": {
+                                    "rach-Report-r16": "supported"
+                                },
+                                "nonCriticalExtension": {
+                                    "nonCriticalExtension": {
+                                        "nonCriticalExtension": {
+                                            "ul-RRC-Segmentation-r16": "supported"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/capabilityInformation/oracle/ueCapNrUlTxSwitchR17R18.json
+++ b/src/test/resources/capabilityInformation/oracle/ueCapNrUlTxSwitchR17R18.json
@@ -1,0 +1,596 @@
+{
+    "nrBands": [
+        {
+            "band": 28,
+            "mimoDl": {
+                "type": "single",
+                "value": 4
+            },
+            "mimoUl": {
+                "type": "single",
+                "value": 1
+            },
+            "modulationDl": {
+                "type": "single",
+                "value": "qam256"
+            },
+            "modulationUl": {
+                "type": "single",
+                "value": "qam256"
+            },
+            "powerClass": "pc3",
+            "bandwidths": [
+                {
+                    "scs": 15,
+                    "bandwidthsDl": [
+                        30,
+                        25,
+                        20,
+                        15,
+                        10,
+                        5
+                    ],
+                    "bandwidthsUl": [
+                        30,
+                        25,
+                        20,
+                        15,
+                        10,
+                        5
+                    ]
+                }
+            ],
+            "rateMatchingLteCrs": true
+        },
+        {
+            "band": 41,
+            "mimoDl": {
+                "type": "single",
+                "value": 4
+            },
+            "mimoUl": {
+                "type": "single",
+                "value": 2
+            },
+            "modulationDl": {
+                "type": "single",
+                "value": "qam1024"
+            },
+            "modulationUl": {
+                "type": "single",
+                "value": "qam256"
+            },
+            "powerClass": "pc1dot5",
+            "bandwidths": [
+                {
+                    "scs": 30,
+                    "bandwidthsDl": [
+                        100,
+                        90,
+                        80,
+                        70,
+                        60,
+                        50,
+                        40,
+                        30,
+                        20,
+                        10
+                    ],
+                    "bandwidthsUl": [
+                        100,
+                        90,
+                        80,
+                        70,
+                        60,
+                        50,
+                        40,
+                        30,
+                        20,
+                        10
+                    ]
+                }
+            ]
+        },
+        {
+            "band": 79,
+            "modulationDl": {
+                "type": "single",
+                "value": "qam1024"
+            },
+            "modulationUl": {
+                "type": "single",
+                "value": "qam256"
+            },
+            "maxUplinkDutyCycle": 50,
+            "powerClass": "pc2",
+            "bandwidths": [
+                {
+                    "scs": 30,
+                    "bandwidthsDl": [
+                        100,
+                        80,
+                        70,
+                        60,
+                        50,
+                        40
+                    ],
+                    "bandwidthsUl": [
+                        100,
+                        80,
+                        70,
+                        60,
+                        50,
+                        40
+                    ]
+                }
+            ]
+        },
+        {
+            "band": 83,
+            "mimoUl": {
+                "type": "single",
+                "value": 1
+            },
+            "modulationUl": {
+                "type": "single",
+                "value": "qam256"
+            },
+            "powerClass": "pc3",
+            "bandwidths": [
+                {
+                    "scs": 15,
+                    "bandwidthsDl": [],
+                    "bandwidthsUl": [
+                        30,
+                        20,
+                        15,
+                        10,
+                        5
+                    ]
+                }
+            ]
+        }
+    ],
+    "nrca": [
+        {
+            "components": [
+                {
+                    "band": 41,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 1
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam1024"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "bw90mhzSupported": true,
+                    "maxScs": 30,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 100
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 100
+                    }
+                },
+                {
+                    "band": 28,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 1
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "maxScs": 15,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 30
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 30
+                    }
+                }
+            ],
+            "bcs": {
+                "type": "multi",
+                "value": [
+                    0,
+                    1,
+                    4
+                ]
+            }
+        },
+        {
+            "components": [
+                {
+                    "band": 41,
+                    "bwClassDl": "C",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 2
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam1024"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "bw90mhzSupported": true,
+                    "maxScs": 30,
+                    "maxBwDl": {
+                        "type": "mixed",
+                        "value": [
+                            100,
+                            90
+                        ]
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 100
+                    }
+                },
+                {
+                    "band": 28,
+                    "bwClassDl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "maxScs": 15,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 30
+                    }
+                }
+            ],
+            "bcs": {
+                "type": "multi",
+                "value": [
+                    0,
+                    4
+                ]
+            }
+        },
+        {
+            "components": [
+                {
+                    "band": 41,
+                    "bwClassDl": "C",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam1024"
+                    },
+                    "bw90mhzSupported": true,
+                    "maxScs": 30,
+                    "maxBwDl": {
+                        "type": "mixed",
+                        "value": [
+                            100,
+                            90
+                        ]
+                    }
+                },
+                {
+                    "band": 28,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 1
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "maxScs": 15,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 30
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 30
+                    }
+                }
+            ],
+            "bcs": {
+                "type": "multi",
+                "value": [
+                    0,
+                    4
+                ]
+            }
+        },
+        {
+            "components": [
+                {
+                    "band": 41,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 2
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam1024"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "bw90mhzSupported": true,
+                    "maxScs": 30,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 100
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 100
+                    },
+                    "ulTxSwitch": true
+                },
+                {
+                    "band": 28,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 1
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "maxScs": 15,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 30
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 30
+                    },
+                    "ulTxSwitch": true
+                }
+            ],
+            "bcs": {
+                "type": "multi",
+                "value": [
+                    0,
+                    1,
+                    4
+                ]
+            },
+            "uplinkTxSwitch": [
+                {
+                    "type": "R16",
+                    "option": "SWITCHED_UL"
+                },
+                {
+                    "type": "R18_1T",
+                    "option": "SWITCHED_UL"
+                }
+            ]
+        },
+        {
+            "components": [
+                {
+                    "band": 83,
+                    "bwClassUl": "A",
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 1
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "maxScs": 15,
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 30
+                    },
+                    "ulTxSwitch": true
+                },
+                {
+                    "band": 41,
+                    "bwClassDl": "A",
+                    "bwClassUl": "A",
+                    "mimoDl": {
+                        "type": "single",
+                        "value": 4
+                    },
+                    "mimoUl": {
+                        "type": "single",
+                        "value": 2
+                    },
+                    "modulationDl": {
+                        "type": "single",
+                        "value": "qam1024"
+                    },
+                    "modulationUl": {
+                        "type": "single",
+                        "value": "qam256"
+                    },
+                    "bw90mhzSupported": true,
+                    "maxScs": 30,
+                    "maxBwDl": {
+                        "type": "single",
+                        "value": 100
+                    },
+                    "maxBwUl": {
+                        "type": "single",
+                        "value": 100
+                    },
+                    "ulTxSwitch": true
+                }
+            ],
+            "bcs": {
+                "type": "multi",
+                "value": [
+                    0,
+                    4
+                ]
+            },
+            "uplinkTxSwitch": [
+                {
+                    "type": "R16",
+                    "option": "SWITCHED_UL"
+                },
+                {
+                    "type": "R18_2T",
+                    "option": "SWITCHED_UL"
+                }
+            ]
+        }
+    ],
+    "logType": "",
+    "ueCapFilters": [
+        {
+            "type": "UeCapabilityFilterNr",
+            "rat": "NR",
+            "nrBands": [
+                {
+                    "band": 41,
+                    "maxCCsDl": 3,
+                    "maxCCsUl": 3
+                },
+                {
+                    "band": 28,
+                    "maxCCsDl": 2,
+                    "maxCCsUl": 2
+                },
+                {
+                    "band": 5,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 8,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 1,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 78,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 77,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 80,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 81,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 82,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 83,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 84,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                },
+                {
+                    "band": 86,
+                    "maxCCsDl": 1,
+                    "maxCCsUl": 1
+                }
+            ],
+            "uplinkTxSwitchRequest": true
+        }
+    ],
+    "ratCapabilities": [
+        {
+            "type": "RatCapabilitiesNr",
+            "release": 17,
+            "ueCapSegmentationSupported": true,
+            "rat": "NR"
+        }
+    ],
+    "metadata": {},
+    "id": "",
+    "parserVersion": "staging",
+    "timestamp": 0
+}


### PR DESCRIPTION
This PR adds detection of R17 and R18 switched uplink for UE Capability Information messages (primarily tested with NSG-formatted messages).

An example input file can be found here (up to R18): https://uecaps.hennes.xyz/view/multi/?id=347c18c4-02a3-4644-9c18-29088f33d76f
Or here (Xiaomi 17 Ultra, R17 2T2T): https://uecaps.hennes.xyz/view/multi/?id=3c23b188-5369-4c1a-892f-46516f450667

For transparency: parts of the code were written with the help of AI and reviewed by a human.